### PR TITLE
fix: mock Copilot session in workflow integration tests

### DIFF
--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -175,3 +175,18 @@ def mock_workflow_state_clearing():
         return_value=None,
     ):
         yield
+
+
+@pytest.fixture
+def mock_copilot_session():
+    """Mock Copilot session start to prevent real subprocess calls and 300s timeouts.
+
+    Workflow initiation commands (e.g., initiate_create_jira_issue_workflow) call
+    _start_copilot_session_for_workflow which polls for a prompt file on disk
+    (300s timeout) and then spawns ``gh copilot``.  Both are undesirable in tests.
+    """
+    with patch(
+        "agentic_devtools.cli.workflows.worktree_setup._start_copilot_session_for_workflow",
+        return_value=False,
+    ):
+        yield

--- a/tests/workflows/test_workflow_end_to_end.py
+++ b/tests/workflows/test_workflow_end_to_end.py
@@ -534,6 +534,7 @@ class TestCreateJiraIssueWorkflowEndToEnd:
         temp_output_dir,
         clear_state_before,
         mock_preflight_pass,
+        mock_copilot_session,
     ):
         """Test that initiating the workflow sets the expected state.
 
@@ -599,6 +600,7 @@ class TestCreateJiraIssueWorkflowEndToEnd:
         temp_output_dir,
         clear_state_before,
         mock_preflight_pass,
+        mock_copilot_session,
         mock_jira_issue_response,
     ):
         """Test that try_advance_workflow_after_jira_issue_retrieved has no side effects.


### PR DESCRIPTION
## Problem

Workflow integration tests were hanging in CI for 10+ minutes. Two tests calling `initiate_create_jira_issue_workflow()` triggered `_start_copilot_session_for_workflow` → `_wait_for_prompt_file` which polls with a **300-second timeout**. The prompt file was written to the mocked `temp_output_dir` (`tmp_path/temp/`) but the session launcher looked for it via `get_state_dir()` (`tmp_path/state/`), so it never found it and blocked for 5 minutes per test.

## Fix

- Added `mock_copilot_session` fixture to `tests/workflows/conftest.py` that mocks `_start_copilot_session_for_workflow` (the common entry point for all workflow Copilot sessions)
- Applied the fixture to both affected tests: `test_initiation_sets_workflow_state` and `test_jira_issue_retrieved_event_has_no_side_effects_on_simple_workflow`

## Result

Full workflow test suite completes in **~2s** instead of **10+ minutes**.