### PR TITLE
fix(#998): prefer REST repository lookup for PR review workflow

### DIFF
--- a/agentic_devtools/cli/azure_devops/config.py
+++ b/agentic_devtools/cli/azure_devops/config.py
@@ -13,6 +13,8 @@ Repository Detection:
 
     Supported URL formats:
     - Azure DevOps HTTPS: https://dev.azure.com/org/project/_git/repo-name
+    - Azure DevOps HTTPS (authenticated): https://user@dev.azure.com/org/project/_git/repo-name
+    - Azure DevOps HTTPS (legacy): https://org.visualstudio.com/project/_git/repo-name
     - Azure DevOps SSH: git@ssh.dev.azure.com:v3/org/project/repo-name
     - Azure DevOps SSH (legacy): org@vs-ssh.visualstudio.com:v3/org/project/repo-name
     - GitHub HTTPS: https://github.com/owner/repo-name.git
@@ -22,6 +24,7 @@ Repository Detection:
 import re
 import subprocess
 from dataclasses import dataclass
+from urllib.parse import unquote
 
 from ...state import get_value
 
@@ -40,22 +43,9 @@ API_VERSION = "7.0"
 # =============================================================================
 
 
-def get_repository_name_from_git_remote() -> str | None:
-    """
-    Extract the repository name from the git remote URL.
-
-    Supports Azure DevOps and GitHub URL formats:
-    - Azure DevOps HTTPS: https://dev.azure.com/org/project/_git/repo-name
-    - Azure DevOps SSH: git@ssh.dev.azure.com:v3/org/project/repo-name
-    - Azure DevOps SSH (legacy): org@vs-ssh.visualstudio.com:v3/org/project/repo-name
-    - GitHub HTTPS: https://github.com/owner/repo-name.git
-    - GitHub SSH: git@github.com:owner/repo-name.git
-
-    Returns:
-        Repository name if found, None otherwise.
-    """
+def _get_git_origin_remote_url() -> str | None:
+    """Return the origin remote URL if available."""
     try:
-        # Get the origin remote URL
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
@@ -63,35 +53,89 @@ def get_repository_name_from_git_remote() -> str | None:
             check=True,
         )
         remote_url = result.stdout.strip()
-
         if not remote_url or not isinstance(remote_url, str):
             return None
-
-        # Azure DevOps HTTPS pattern: https://dev.azure.com/org/project/_git/repo-name
-        azure_match = re.search(r"/_git/([^/?#]+)", remote_url)
-        if azure_match:
-            return azure_match.group(1)
-
-        # Azure DevOps SSH patterns:
-        # New format: git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
-        # Legacy format: {org}@vs-ssh.visualstudio.com:v3/{org}/{project}/{repo}
-        azure_ssh_match = re.search(
-            r"(?:ssh\.dev\.azure\.com|vs-ssh\.visualstudio\.com):v3/[^/]+/[^/]+/([^/\s]+?)(?:\.git)?$",
-            remote_url,
-        )
-        if azure_ssh_match:
-            return azure_ssh_match.group(1)
-
-        # GitHub HTTPS pattern: https://github.com/owner/repo-name.git
-        github_https_match = re.search(r"github\.com[:/][\w-]+/([\w-]+?)(?:\.git)?$", remote_url)
-        if github_https_match:
-            return github_https_match.group(1)
-
-        return None
-
+        return remote_url
     except (subprocess.CalledProcessError, FileNotFoundError, AttributeError, TypeError):
-        # Git command failed, git not available, or mocked incorrectly in tests
         return None
+
+
+def _parse_azure_devops_context_from_remote_url(remote_url: str) -> tuple[str, str, str] | None:
+    """Extract Azure DevOps organization, project, and repository from a remote URL."""
+    azure_https_match = re.search(
+        r"^https://(?:[^@/]+@)?dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/?#]+)",
+        remote_url,
+    )
+    if azure_https_match:
+        organization_name, project, repository = azure_https_match.groups()
+        return (f"https://dev.azure.com/{organization_name}", unquote(project), unquote(repository))
+
+    legacy_azure_https_match = re.search(
+        r"^https://([^.]+)\.visualstudio\.com/([^/]+)/_git/([^/?#]+)",
+        remote_url,
+    )
+    if legacy_azure_https_match:
+        organization_name, project, repository = legacy_azure_https_match.groups()
+        return (f"https://dev.azure.com/{organization_name}", unquote(project), unquote(repository))
+
+    azure_ssh_match = re.search(
+        r"(?:ssh\.dev\.azure\.com|vs-ssh\.visualstudio\.com):v3/([^/]+)/([^/]+)/([^/\s]+?)(?:\.git)?$",
+        remote_url,
+    )
+    if azure_ssh_match:
+        organization_name, project, repository = azure_ssh_match.groups()
+        return (f"https://dev.azure.com/{organization_name}", unquote(project), unquote(repository))
+
+    return None
+
+
+def get_azure_devops_context_from_git_remote() -> tuple[str, str, str] | None:
+    """
+    Extract Azure DevOps organization, project, and repository from the git remote URL.
+
+    Returns:
+        Tuple of (organization_url, project, repository) for Azure DevOps remotes,
+        or None for non-Azure-DevOps remotes and lookup failures.
+    """
+    remote_url = _get_git_origin_remote_url()
+    if not remote_url:
+        return None
+
+    return _parse_azure_devops_context_from_remote_url(remote_url)
+
+
+def get_repository_name_from_git_remote() -> str | None:
+    """
+    Extract the repository name from the git remote URL.
+
+    Supports Azure DevOps and GitHub URL formats:
+    - Azure DevOps HTTPS: https://dev.azure.com/org/project/_git/repo-name
+    - Azure DevOps HTTPS (authenticated): https://user@dev.azure.com/org/project/_git/repo-name
+    - Azure DevOps HTTPS (legacy): https://org.visualstudio.com/project/_git/repo-name
+    - Azure DevOps SSH: git@ssh.dev.azure.com:v3/org/project/repo-name
+    - Azure DevOps SSH (legacy): org@vs-ssh.visualstudio.com:v3/org/project/repo-name
+    - GitHub HTTPS: https://github.com/owner/repo-name.git
+    - GitHub SSH: git@github.com:owner/repo-name.git
+
+    Percent-encoded segments (e.g. ``My%20Project``) are decoded automatically.
+
+    Returns:
+        Repository name if found, None otherwise.
+    """
+    remote_url = _get_git_origin_remote_url()
+    if not remote_url:
+        return None
+
+    azure_devops_context = _parse_azure_devops_context_from_remote_url(remote_url)
+    if azure_devops_context:
+        return azure_devops_context[2]
+
+    # GitHub HTTPS pattern: https://github.com/owner/repo-name.git
+    github_https_match = re.search(r"github\.com[:/][\w-]+/([\w-]+?)(?:\.git)?$", remote_url)
+    if github_https_match:
+        return github_https_match.group(1)
+
+    return None
 
 
 # =============================================================================
@@ -112,14 +156,23 @@ class AzureDevOpsConfig:
     @classmethod
     def from_state(cls) -> "AzureDevOpsConfig":
         """Create config from state values or defaults."""
-        # Try to get repository from state, then git remote, then hardcoded default
-        repository = get_value("repository")
-        if not repository:
-            repository = get_repository_name_from_git_remote() or DEFAULT_REPOSITORY
+        remote_context = get_azure_devops_context_from_git_remote()
+        remote_organization = remote_context[0] if remote_context else None
+        remote_project = remote_context[1] if remote_context else None
+        remote_repository = remote_context[2] if remote_context else None
+
+        # Only call get_repository_name_from_git_remote() when remote_context is None
+        # (i.e., non-Azure-DevOps remote such as GitHub) to avoid running
+        # `git remote get-url origin` twice on every config load.
+        repository_from_git_remote = None if remote_context else get_repository_name_from_git_remote()
+
+        repository = get_value("repository") or remote_repository or repository_from_git_remote or DEFAULT_REPOSITORY
+        organization = get_value("organization") or remote_organization or DEFAULT_ORGANIZATION
+        project = get_value("project") or remote_project or DEFAULT_PROJECT
 
         return cls(
-            organization=get_value("organization") or DEFAULT_ORGANIZATION,
-            project=get_value("project") or DEFAULT_PROJECT,
+            organization=organization,
+            project=project,
             repository=repository,
         )
 

--- a/agentic_devtools/cli/azure_devops/helpers.py
+++ b/agentic_devtools/cli/azure_devops/helpers.py
@@ -11,15 +11,46 @@ import subprocess
 import sys
 import time
 from typing import Any
+from urllib.parse import quote, unquote
 
 from ...state import is_safe_dir_segment
 from ..subprocess_utils import run_safe
 from .config import (
+    API_VERSION,
     DEFAULT_ORGANIZATION,
     DEFAULT_PROJECT,
     DEFAULT_REPOSITORY,
     AzureDevOpsConfig,
 )
+
+
+def _get_repository_id_via_rest(
+    organization: str,
+    project: str,
+    repository: str,
+) -> str:
+    """Resolve the repository ID via Azure DevOps REST API using PAT auth."""
+    requests = require_requests()
+
+    from .auth import get_auth_headers, get_pat
+
+    headers = get_auth_headers(get_pat())
+    # Normalize to avoid double-encoding values that may already be
+    # percent-encoded (e.g. from a git remote URL).
+    project_encoded = quote(unquote(project), safe="")
+    repository_encoded = quote(unquote(repository), safe="")
+    url = f"{organization.rstrip('/')}/{project_encoded}/_apis/git/repositories/{repository_encoded}?api-version={API_VERSION}"
+
+    response = requests.get(url, headers=headers, timeout=30)
+    if response.status_code != 200:
+        raise RuntimeError(f"REST API returned {response.status_code}: {response.text.strip() or 'No response body'}")
+
+    data = response.json()
+    repo_id = (data.get("id") or "").strip()
+    if not repo_id:
+        raise RuntimeError("REST API response did not include a repository id")
+
+    return repo_id
 
 
 def parse_bool_from_state_value(raw_value, default: bool = False) -> bool:
@@ -59,7 +90,22 @@ def get_repository_id(
     project: str = DEFAULT_PROJECT,
     repository: str = DEFAULT_REPOSITORY,
 ) -> str:
-    """Get the repository ID using Azure CLI."""
+    """Get the repository ID, preferring REST and falling back to Azure CLI."""
+    rest_error_message: str | None = None
+    try:
+        return _get_repository_id_via_rest(
+            organization=organization,
+            project=project,
+            repository=repository,
+        )
+    except Exception as rest_error:
+        rest_error_message = f"REST lookup failed for '{repository}': {rest_error}"
+
+    # Azure CLI expects human-readable names; values derived from remotes may
+    # already be percent-encoded (e.g. "My%20Project").
+    project_for_cli = unquote(project)
+    repository_for_cli = unquote(repository)
+
     cmd = [
         "az",
         "repos",
@@ -67,9 +113,9 @@ def get_repository_id(
         "--organization",
         organization,
         "--project",
-        project,
+        project_for_cli,
         "--repository",
-        repository,
+        repository_for_cli,
         "--query",
         "id",
         "--output",
@@ -78,14 +124,15 @@ def get_repository_id(
 
     result = run_safe(cmd, capture_output=True, text=True)
 
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to get repository ID for '{repository}': {result.stderr}")
+    if result.returncode == 0:
+        repo_id = result.stdout.strip()
+        if repo_id:
+            return repo_id
+        cli_error = f"Empty repository ID returned for '{repository}'"
+    else:
+        cli_error = f"Failed to get repository ID for '{repository}': {result.stderr}"
 
-    repo_id = result.stdout.strip()
-    if not repo_id:
-        raise RuntimeError(f"Empty repository ID returned for '{repository}'")
-
-    return repo_id
+    raise RuntimeError(f"{rest_error_message}\nAzure CLI fallback failed: {cli_error}")
 
 
 def resolve_thread_by_id(

--- a/tests/azure_devops/conftest.py
+++ b/tests/azure_devops/conftest.py
@@ -27,17 +27,20 @@ def clear_state_before(temp_state_dir):
 def mock_git_remote_detection(request, monkeypatch):
     """
     Auto-mock git remote detection for all Azure DevOps tests except
-    tests in TestRepositoryDetection class which specifically test that function.
+    tests in TestRepositoryDetection / TestGetAzureDevOpsContextFromGitRemote
+    classes which specifically test those functions.
 
     This prevents the git remote detection from interfering with test mocks
-    by making it always return None (which causes fallback to DEFAULT_REPOSITORY).
+    by making it always return None (which causes fallback to defaults).
     """
-    # Skip this fixture for tests in TestRepositoryDetection class
-    if "TestRepositoryDetection" in request.node.nodeid:
+    # Skip this fixture for tests that specifically test git remote detection
+    skip_classes = ("TestRepositoryDetection", "TestGetAzureDevOpsContextFromGitRemote")
+    if any(cls in request.node.nodeid for cls in skip_classes):
         yield
         return
 
     from agentic_devtools.cli.azure_devops import config
 
     monkeypatch.setattr(config, "get_repository_name_from_git_remote", lambda: None)
+    monkeypatch.setattr(config, "get_azure_devops_context_from_git_remote", lambda: None)
     yield

--- a/tests/unit/cli/azure_devops/config/test__parse_azure_devops_context_from_remote_url.py
+++ b/tests/unit/cli/azure_devops/config/test__parse_azure_devops_context_from_remote_url.py
@@ -1,0 +1,37 @@
+"""Tests for _parse_azure_devops_context_from_remote_url."""
+
+from agentic_devtools.cli.azure_devops.config import _parse_azure_devops_context_from_remote_url
+
+
+class TestParseAzureDevopsContextFromRemoteUrl:
+    """Tests for _parse_azure_devops_context_from_remote_url function."""
+
+    def test_decodes_percent_encoded_project_and_repository(self):
+        """Test that percent-encoded segments in project and repository are decoded."""
+        url = "https://dev.azure.com/myorg/My%20Project/_git/My%20Repo"
+        result = _parse_azure_devops_context_from_remote_url(url)
+        assert result == ("https://dev.azure.com/myorg", "My Project", "My Repo")
+
+    def test_decodes_percent_encoded_legacy_url(self):
+        """Test that percent-encoded segments are decoded for legacy visualstudio.com URLs."""
+        url = "https://myorg.visualstudio.com/My%20Project/_git/My%20Repo"
+        result = _parse_azure_devops_context_from_remote_url(url)
+        assert result == ("https://dev.azure.com/myorg", "My Project", "My Repo")
+
+    def test_decodes_percent_encoded_ssh_url(self):
+        """Test that percent-encoded segments are decoded for SSH URLs."""
+        url = "git@ssh.dev.azure.com:v3/myorg/My%20Project/My%20Repo"
+        result = _parse_azure_devops_context_from_remote_url(url)
+        assert result == ("https://dev.azure.com/myorg", "My Project", "My Repo")
+
+    def test_returns_none_for_non_azure_url(self):
+        """Test that non-Azure DevOps URLs return None."""
+        url = "https://github.com/owner/repo.git"
+        result = _parse_azure_devops_context_from_remote_url(url)
+        assert result is None
+
+    def test_plain_segments_unchanged(self):
+        """Test that URLs without percent-encoding still work correctly."""
+        url = "https://dev.azure.com/swica/DragonflyMgmt/_git/dfly-platform-management"
+        result = _parse_azure_devops_context_from_remote_url(url)
+        assert result == ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management")

--- a/tests/unit/cli/azure_devops/config/test_azure_devops_config.py
+++ b/tests/unit/cli/azure_devops/config/test_azure_devops_config.py
@@ -32,6 +32,64 @@ class TestAzureDevOpsConfig:
         assert config.project == "CustomProject"
         assert config.repository == "custom-repo"
 
+    def test_from_state_uses_azure_devops_git_remote_context(self, temp_state_dir, clear_state_before, monkeypatch):
+        """Test config uses organization and project inferred from Azure DevOps git remote."""
+        monkeypatch.setattr(
+            azure_devops.config,
+            "get_azure_devops_context_from_git_remote",
+            lambda: ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management"),
+        )
+
+        config = azure_devops.AzureDevOpsConfig.from_state()
+        assert config.organization == "https://dev.azure.com/swica"
+        assert config.project == "DragonflyMgmt"
+        assert config.repository == "dfly-platform-management"
+
+    def test_from_state_falls_back_to_github_remote_for_repository(
+        self, temp_state_dir, clear_state_before, monkeypatch
+    ):
+        """Test config falls back to get_repository_name_from_git_remote for non-Azure-DevOps remotes."""
+        monkeypatch.setattr(
+            azure_devops.config,
+            "get_azure_devops_context_from_git_remote",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            azure_devops.config,
+            "get_repository_name_from_git_remote",
+            lambda: "agentic-devtools",
+        )
+
+        config = azure_devops.AzureDevOpsConfig.from_state()
+        assert config.repository == "agentic-devtools"
+        assert config.organization == azure_devops.DEFAULT_ORGANIZATION
+        assert config.project == azure_devops.DEFAULT_PROJECT
+
+    def test_from_state_skips_repository_name_lookup_when_azure_remote_context_exists(
+        self, temp_state_dir, clear_state_before, monkeypatch
+    ):
+        """Test Azure DevOps remote context avoids a second git remote lookup."""
+        monkeypatch.setattr(
+            azure_devops.config,
+            "get_azure_devops_context_from_git_remote",
+            lambda: ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management"),
+        )
+
+        def fail_if_called():
+            raise AssertionError("get_repository_name_from_git_remote should not be called when Azure context exists")
+
+        monkeypatch.setattr(
+            azure_devops.config,
+            "get_repository_name_from_git_remote",
+            fail_if_called,
+        )
+
+        config = azure_devops.AzureDevOpsConfig.from_state()
+
+        assert config.organization == "https://dev.azure.com/swica"
+        assert config.project == "DragonflyMgmt"
+        assert config.repository == "dfly-platform-management"
+
     def test_build_api_url_simple(self):
         """Test building simple API URL."""
         config = azure_devops.AzureDevOpsConfig(

--- a/tests/unit/cli/azure_devops/config/test_get_azure_devops_context_from_git_remote.py
+++ b/tests/unit/cli/azure_devops/config/test_get_azure_devops_context_from_git_remote.py
@@ -1,0 +1,95 @@
+"""Tests for get_azure_devops_context_from_git_remote."""
+
+
+class TestGetAzureDevOpsContextFromGitRemote:
+    """Tests for get_azure_devops_context_from_git_remote function."""
+
+    def test_extracts_context_from_azure_devops_https_remote(self, monkeypatch):
+        """Test extracting organization, project, and repository from Azure DevOps HTTPS remote."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "https://dev.azure.com/swica/DragonflyMgmt/_git/dfly-platform-management"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_azure_devops_context_from_git_remote
+
+        result = get_azure_devops_context_from_git_remote()
+        assert result == ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management")
+
+    def test_extracts_context_from_azure_devops_ssh_remote(self, monkeypatch):
+        """Test extracting organization, project, and repository from Azure DevOps SSH remote."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "git@ssh.dev.azure.com:v3/swica/DragonflyMgmt/dfly-platform-management"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_azure_devops_context_from_git_remote
+
+        result = get_azure_devops_context_from_git_remote()
+        assert result == ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management")
+
+    def test_extracts_context_from_authenticated_azure_devops_https_remote(self, monkeypatch):
+        """Test extracting context from an authenticated dev.azure.com remote URL."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "https://albert@dev.azure.com/swica/DragonflyMgmt/_git/dfly-platform-management"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_azure_devops_context_from_git_remote
+
+        result = get_azure_devops_context_from_git_remote()
+        assert result == ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management")
+
+    def test_extracts_context_from_legacy_azure_devops_https_remote(self, monkeypatch):
+        """Test extracting context from a legacy visualstudio.com remote URL."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "https://swica.visualstudio.com/DragonflyMgmt/_git/dfly-platform-management"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_azure_devops_context_from_git_remote
+
+        result = get_azure_devops_context_from_git_remote()
+        assert result == ("https://dev.azure.com/swica", "DragonflyMgmt", "dfly-platform-management")
+
+    def test_returns_none_for_non_azure_devops_remote(self, monkeypatch):
+        """Test returning None for non-Azure-DevOps remotes."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "https://github.com/ayaiayorg/agentic-devtools.git"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_azure_devops_context_from_git_remote
+
+        result = get_azure_devops_context_from_git_remote()
+        assert result is None

--- a/tests/unit/cli/azure_devops/config/test_get_repository_name_from_git_remote.py
+++ b/tests/unit/cli/azure_devops/config/test_get_repository_name_from_git_remote.py
@@ -97,6 +97,42 @@ class TestRepositoryDetection:
         result = get_repository_name_from_git_remote()
         assert result == "agentic-devtools"
 
+    def test_get_repository_name_from_authenticated_azure_devops_https(self, monkeypatch):
+        """Test extracting repository name from authenticated Azure DevOps HTTPS URL."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "https://albert@dev.azure.com/example-org/ExampleProject/_git/example-repo-name"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_repository_name_from_git_remote
+
+        result = get_repository_name_from_git_remote()
+        assert result == "example-repo-name"
+
+    def test_get_repository_name_from_legacy_azure_devops_https(self, monkeypatch):
+        """Test extracting repository name from legacy Azure DevOps HTTPS URL."""
+        import subprocess
+
+        def mock_run(*args, **kwargs):
+            class MockResult:
+                stdout = "https://example-org.visualstudio.com/ExampleProject/_git/example-repo-name"
+                returncode = 0
+
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        from agentic_devtools.cli.azure_devops.config import get_repository_name_from_git_remote
+
+        result = get_repository_name_from_git_remote()
+        assert result == "example-repo-name"
+
     def test_get_repository_name_from_azure_devops_ssh(self, monkeypatch):
         """Test extracting repository name from Azure DevOps SSH URL (new format)."""
         import subprocess

--- a/tests/unit/cli/azure_devops/conftest.py
+++ b/tests/unit/cli/azure_devops/conftest.py
@@ -21,17 +21,20 @@ def mock_azure_devops_env():
 def mock_git_remote_detection(request, monkeypatch):
     """
     Auto-mock git remote detection for all Azure DevOps tests except
-    tests in TestRepositoryDetection class which specifically test that function.
+    tests in TestRepositoryDetection / TestGetAzureDevOpsContextFromGitRemote
+    classes which specifically test those functions.
 
     This prevents the git remote detection from interfering with test mocks
-    by making it always return None (which causes fallback to DEFAULT_REPOSITORY).
+    by making it always return None (which causes fallback to defaults).
     """
-    # Skip this fixture for tests in TestRepositoryDetection class
-    if "TestRepositoryDetection" in request.node.nodeid:
+    # Skip this fixture for tests that specifically test git remote detection
+    skip_classes = ("TestRepositoryDetection", "TestGetAzureDevOpsContextFromGitRemote")
+    if any(cls in request.node.nodeid for cls in skip_classes):
         yield
         return
 
     from agentic_devtools.cli.azure_devops import config
 
     monkeypatch.setattr(config, "get_repository_name_from_git_remote", lambda: None)
+    monkeypatch.setattr(config, "get_azure_devops_context_from_git_remote", lambda: None)
     yield

--- a/tests/unit/cli/azure_devops/helpers/test__get_repository_id_via_rest.py
+++ b/tests/unit/cli/azure_devops/helpers/test__get_repository_id_via_rest.py
@@ -1,0 +1,188 @@
+"""Tests for _get_repository_id_via_rest helper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentic_devtools.cli.azure_devops.config import API_VERSION
+
+
+class TestGetRepositoryIdViaRest:
+    """Tests for _get_repository_id_via_rest function."""
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_returns_repo_id_on_success(self):
+        """Test successful REST repository ID lookup."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "repo-guid-abc"}
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            result = _get_repository_id_via_rest(
+                organization="https://dev.azure.com/myorg",
+                project="MyProject",
+                repository="my-repo",
+            )
+
+        assert result == "repo-guid-abc"
+        mock_requests.get.assert_called_once()
+        call_url = mock_requests.get.call_args[0][0]
+        assert "MyProject/_apis/git/repositories/my-repo" in call_url
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_raises_on_non_200_status(self):
+        """Test raises RuntimeError on non-200 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            with pytest.raises(RuntimeError, match="REST API returned 404"):
+                _get_repository_id_via_rest(
+                    organization="https://dev.azure.com/myorg",
+                    project="MyProject",
+                    repository="missing-repo",
+                )
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_raises_when_response_missing_id(self):
+        """Test raises RuntimeError when response has no id field."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "my-repo"}
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            with pytest.raises(RuntimeError, match="did not include a repository id"):
+                _get_repository_id_via_rest(
+                    organization="https://dev.azure.com/myorg",
+                    project="MyProject",
+                    repository="my-repo",
+                )
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_url_encodes_project_and_repository(self):
+        """Test that project and repository names are URL-encoded."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "repo-guid"}
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            _get_repository_id_via_rest(
+                organization="https://dev.azure.com/myorg",
+                project="My Project",
+                repository="my repo",
+            )
+
+        call_url = mock_requests.get.call_args[0][0]
+        assert "My%20Project" in call_url
+        assert "my%20repo" in call_url
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_strips_trailing_slash_from_organization(self):
+        """Test that trailing slash in organization URL is stripped."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "repo-guid"}
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            _get_repository_id_via_rest(
+                organization="https://dev.azure.com/myorg/",
+                project="MyProject",
+                repository="my-repo",
+            )
+
+        call_url = mock_requests.get.call_args[0][0]
+        assert "myorg//MyProject" not in call_url
+        assert "myorg/MyProject" in call_url
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_uses_shared_api_version_constant(self):
+        """Test REST lookup uses the shared API version constant from config."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "repo-guid"}
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            _get_repository_id_via_rest(
+                organization="https://dev.azure.com/myorg",
+                project="MyProject",
+                repository="my-repo",
+            )
+
+        call_url = mock_requests.get.call_args[0][0]
+        assert call_url.endswith(f"?api-version={API_VERSION}")
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_raises_on_empty_response_body(self):
+        """Test raises RuntimeError with descriptive message on empty response body."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = ""
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            with pytest.raises(RuntimeError, match="No response body"):
+                _get_repository_id_via_rest(
+                    organization="https://dev.azure.com/myorg",
+                    project="MyProject",
+                    repository="my-repo",
+                )
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    def test_does_not_double_encode_percent_encoded_values(self):
+        """Test that already percent-encoded values are normalized (unquote then quote)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "repo-guid"}
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        with patch("agentic_devtools.cli.azure_devops.helpers.require_requests", return_value=mock_requests):
+            from agentic_devtools.cli.azure_devops.helpers import _get_repository_id_via_rest
+
+            _get_repository_id_via_rest(
+                organization="https://dev.azure.com/myorg",
+                project="My%20Project",
+                repository="my%20repo",
+            )
+
+        call_url = mock_requests.get.call_args[0][0]
+        # Should be single-encoded, not double-encoded (%2520)
+        assert "My%20Project" in call_url
+        assert "my%20repo" in call_url
+        assert "%2520" not in call_url

--- a/tests/unit/cli/azure_devops/helpers/test_get_repository_id.py
+++ b/tests/unit/cli/azure_devops/helpers/test_get_repository_id.py
@@ -10,32 +10,86 @@ from agentic_devtools.cli import azure_devops
 class TestGetRepositoryId:
     """Tests for get_repository_id function."""
 
-    def test_successful_repo_id_fetch(self):
-        """Test successful repository ID fetch."""
+    def test_uses_rest_as_first_lookup_option(self, mock_azure_devops_env):
+        """Test repository ID is resolved from REST before Azure CLI is attempted."""
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers._get_repository_id_via_rest", return_value="repo-guid-123"
+        ):
+            with patch("agentic_devtools.cli.azure_devops.helpers.run_safe") as mock_run_safe:
+                repo_id = azure_devops.get_repository_id()
+
+        assert repo_id == "repo-guid-123"
+        mock_run_safe.assert_not_called()
+
+    def test_falls_back_to_az_when_rest_lookup_fails(self):
+        """Test Azure CLI is used when REST lookup fails."""
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = "repo-guid-123\n"
 
-        with patch("subprocess.run", return_value=mock_result):
-            repo_id = azure_devops.get_repository_id()
-            assert repo_id == "repo-guid-123"
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers._get_repository_id_via_rest",
+            side_effect=RuntimeError("REST failed"),
+        ):
+            with patch("agentic_devtools.cli.azure_devops.helpers.run_safe", return_value=mock_result):
+                repo_id = azure_devops.get_repository_id()
 
-    def test_raises_on_command_failure(self):
-        """Test raises RuntimeError on command failure."""
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        mock_result.stderr = "Command failed"
+        assert repo_id == "repo-guid-123"
 
-        with patch("subprocess.run", return_value=mock_result):
-            with pytest.raises(RuntimeError, match="Failed to get repository ID"):
-                azure_devops.get_repository_id()
+    def test_raises_when_rest_and_az_fail(self):
+        """Test error contains both REST and Azure CLI failures."""
+        cli_result = MagicMock()
+        cli_result.returncode = 1
+        cli_result.stderr = "VS800075"
 
-    def test_raises_on_empty_result(self):
-        """Test raises RuntimeError on empty result."""
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers._get_repository_id_via_rest",
+            side_effect=RuntimeError("Forbidden"),
+        ):
+            with patch("agentic_devtools.cli.azure_devops.helpers.run_safe", return_value=cli_result):
+                with pytest.raises(RuntimeError, match="REST lookup failed") as exc_info:
+                    azure_devops.get_repository_id(
+                        organization="https://dev.azure.com/swica",
+                        project="DragonflyMgmt",
+                        repository="dfly-platform-management",
+                    )
+
+        assert "Azure CLI fallback failed" in str(exc_info.value)
+
+    def test_raises_when_rest_fails_and_az_returns_empty_result(self):
+        """Test empty Azure CLI fallback result is surfaced after REST failure."""
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = ""
 
-        with patch("subprocess.run", return_value=mock_result):
-            with pytest.raises(RuntimeError, match="Empty repository ID"):
-                azure_devops.get_repository_id()
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers._get_repository_id_via_rest",
+            side_effect=RuntimeError("Forbidden"),
+        ):
+            with patch("agentic_devtools.cli.azure_devops.helpers.run_safe", return_value=mock_result):
+                with pytest.raises(RuntimeError, match="Empty repository ID"):
+                    azure_devops.get_repository_id()
+
+    def test_decodes_percent_encoded_values_for_azure_cli_fallback(self):
+        """Test Azure CLI fallback uses decoded project/repository names."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "repo-guid-123\n"
+
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers._get_repository_id_via_rest",
+            side_effect=RuntimeError("Forbidden"),
+        ):
+            with patch("agentic_devtools.cli.azure_devops.helpers.run_safe", return_value=mock_result) as mock_run_safe:
+                repo_id = azure_devops.get_repository_id(
+                    organization="https://dev.azure.com/swica",
+                    project="Dragonfly%20Mgmt",
+                    repository="dfly-platform%20management",
+                )
+
+        assert repo_id == "repo-guid-123"
+        called_cmd = mock_run_safe.call_args[0][0]
+        assert "Dragonfly Mgmt" in called_cmd
+        assert "dfly-platform management" in called_cmd
+        assert "Dragonfly%20Mgmt" not in called_cmd
+        assert "dfly-platform%20management" not in called_cmd

--- a/tests/unit/context/retriever/test_issuecontextretriever.py
+++ b/tests/unit/context/retriever/test_issuecontextretriever.py
@@ -340,9 +340,7 @@ class TestRetrieve:
 
         config = _make_config()
         retriever = IssueContextRetriever(jira_config=config, repo_path=str(tmp_path))
-        with patch.object(
-            IssueContextRetriever, "_validate_path", side_effect=OSError("filesystem error")
-        ):
+        with patch.object(IssueContextRetriever, "_validate_path", side_effect=OSError("filesystem error")):
             ctx = await retriever.retrieve("T-1", affected_paths=["some/file.py"])
 
         assert ctx.relevant_files == []


### PR DESCRIPTION
- [x] Investigate CI failures (StopIteration in 90+ tests)
- [x] Root cause: conftest `mock_git_remote_detection` didn't mock the new `get_azure_devops_context_from_git_remote` function, causing subprocess.run calls to consume side_effect entries
- [x] Fix both conftest.py files to mock `get_azure_devops_context_from_git_remote`
- [x] Add skip condition for `TestGetAzureDevOpsContextFromGitRemote` test class
- [x] Add unit tests for `_get_repository_id_via_rest` (6 tests covering success, errors, URL encoding)
- [x] Full test suite: 7119 passed, 100% coverage
- [x] CodeQL: no alerts

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.