### PR TITLE
fix(#1491): skip dedup guard for pull_request_review submitted events

### DIFF
--- a/agentic_devtools/cli/ci/orchestrator.py
+++ b/agentic_devtools/cli/ci/orchestrator.py
@@ -114,8 +114,7 @@ def _is_ci_completion_event(event_payload: EventPayload) -> bool:
 
 def _is_review_submission_event(event_payload: EventPayload) -> bool:
     """Return True when this run was triggered by a PR review submission."""
-    # Empty action keeps legacy tests/backward-compatible callers working.
-    return event_payload.action in {"submitted", ""}
+    return event_payload.action == "submitted"
 
 
 def _is_wip_title(title: str) -> bool:
@@ -410,33 +409,43 @@ def run_ai_pr_loop(
 
     # 3e: Deduplication — checked after CI pending short-circuit so that
     # re-triggers while CI is still running don't consume the dispatch budget.
+    # Review submission events are external triggers (Copilot or human submitting
+    # a review) and are not caused by the loop itself, so they always bypass
+    # deduplication regardless of how many repair dispatches have already occurred.
     _log_group("Step 3e–3f: Deduplication and cycle guards")
     dedup_sha = event_payload.head_sha or pr_meta.head_sha
-    try:
-        dedup_skip, dedup_count = check_deduplication(provider, pr_number, dedup_sha)
-    except Exception as exc:
-        logger.error("Deduplication check failed for PR #%d: %s", pr_number, exc)
-        summary["decision"] = "error"
-        summary["reason"] = "deduplication_failed"
-        summary["error"] = str(exc)
-        summary["exit_code"] = EXIT_METADATA_FAILED
-        _log_endgroup()
-        _emit_decision_summary(summary)
-        return EXIT_METADATA_FAILED
-    if dedup_skip:
-        logger.info(
-            "PR #%d dispatch limit reached for sha=%s (count=%d) — skipping",
-            pr_number,
-            dedup_sha[:8],
-            dedup_count,
-        )
-        summary["guards"] = {"blocked_by": "deduplication", "sha": dedup_sha[:8], "count": dedup_count}
-        summary["decision"] = "blocked"
-        summary["reason"] = "dedup_limit"
-        summary["exit_code"] = EXIT_GUARD_BLOCKED
-        _log_endgroup()
-        _emit_decision_summary(summary)
-        return EXIT_GUARD_BLOCKED
+    dedup_skip = False
+    dedup_count = 0
+    dedup_bypassed = False
+    if _is_review_submission_event(event_payload):
+        dedup_bypassed = True
+        logger.info("PR #%d — review submission event; dedup check bypassed", pr_number)
+    else:
+        try:
+            dedup_skip, dedup_count = check_deduplication(provider, pr_number, dedup_sha)
+        except Exception as exc:
+            logger.error("Deduplication check failed for PR #%d: %s", pr_number, exc)
+            summary["decision"] = "error"
+            summary["reason"] = "deduplication_failed"
+            summary["error"] = str(exc)
+            summary["exit_code"] = EXIT_METADATA_FAILED
+            _log_endgroup()
+            _emit_decision_summary(summary)
+            return EXIT_METADATA_FAILED
+        if dedup_skip:
+            logger.info(
+                "PR #%d dispatch limit reached for sha=%s (count=%d) — skipping",
+                pr_number,
+                dedup_sha[:8],
+                dedup_count,
+            )
+            summary["guards"] = {"blocked_by": "deduplication", "sha": dedup_sha[:8], "count": dedup_count}
+            summary["decision"] = "blocked"
+            summary["reason"] = "dedup_limit"
+            summary["exit_code"] = EXIT_GUARD_BLOCKED
+            _log_endgroup()
+            _emit_decision_summary(summary)
+            return EXIT_GUARD_BLOCKED
 
     # 3f: Cycle limit — checked after CI pending short-circuit so that
     # re-triggers while CI is still running don't exhaust the cycle budget.
@@ -460,7 +469,14 @@ def run_ai_pr_loop(
         _log_endgroup()
         _emit_decision_summary(summary)
         return EXIT_GUARD_BLOCKED
-    logger.info("PR #%d passed dedup (count=%d) and cycle (count=%d) guards", pr_number, dedup_count, cycle_count)
+    if dedup_bypassed:
+        logger.info(
+            "PR #%d dedup bypassed (review submission) and cycle (count=%d) guards passed",
+            pr_number,
+            cycle_count,
+        )
+    else:
+        logger.info("PR #%d passed dedup (count=%d) and cycle (count=%d) guards", pr_number, dedup_count, cycle_count)
     _log_endgroup()
 
     # Step 5: Evaluate reviews

--- a/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop.py
+++ b/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop.py
@@ -81,7 +81,7 @@ class TestRunAIPRLoop:
     def test_full_happy_path_merges(self) -> None:
         """PR with passing checks and approval gets merged."""
         provider = _make_provider()
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
 
         result = run_ai_pr_loop(provider, payload)
 
@@ -106,13 +106,13 @@ class TestRunAIPRLoop:
 
     def test_privileged_paths_blocked(self) -> None:
         provider = _make_provider(files=[".github/workflows/ci.yml"])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_GUARD_BLOCKED
 
     def test_docker_files_blocked(self) -> None:
         provider = _make_provider(files=["Dockerfile"])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_GUARD_BLOCKED
 
@@ -153,7 +153,7 @@ class TestRunAIPRLoop:
 
     def test_pending_checks_waits(self) -> None:
         provider = _make_provider(check_runs=[CheckRunStatus(id=1, name="Tests ✅", status="in_progress")])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.merge_pr.assert_not_called()
@@ -193,7 +193,7 @@ class TestRunAIPRLoop:
             reviews=[ReviewInfo(id=1, user="copilot-pull-request-reviewer[bot]", state="COMMENTED", body="lgtm")]
         )
         provider.list_review_comments.return_value = []
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.approve_pr.assert_called_once()
@@ -207,7 +207,7 @@ class TestRunAIPRLoop:
             100,
             "<!-- repair-dispatch:abc123:3 -->\nTracking",
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_GUARD_BLOCKED
 
@@ -219,7 +219,7 @@ class TestRunAIPRLoop:
             None,  # dedup: no marker
             (200, "<!-- ai-pr-loop-cycle-tracker --> cycle:50"),  # cycle: at limit
         ]
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_GUARD_BLOCKED
 
@@ -230,7 +230,7 @@ class TestRunAIPRLoop:
         )
         provider.dispatch_repair.return_value = 200
         provider.list_review_comments.return_value = ["fix this"]
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_REPAIR_DISPATCHED
         provider.merge_pr.assert_not_called()
@@ -240,7 +240,7 @@ class TestRunAIPRLoop:
     def test_human_changes_requested_does_not_dispatch_repair(self) -> None:
         """Human CHANGES_REQUESTED blocks merge but does NOT trigger repair."""
         provider = _make_provider(reviews=[ReviewInfo(id=1, user="reviewer", state="CHANGES_REQUESTED", body="fix")])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.merge_pr.assert_not_called()
@@ -252,7 +252,7 @@ class TestRunAIPRLoop:
 
         provider = _make_provider()
         provider.merge_pr.side_effect = RuntimeError("merge conflict")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_MERGE_BLOCKED
 
@@ -265,7 +265,7 @@ class TestRunAIPRLoop:
                 CheckRunStatus(id=1, name="Tests ✅", status="completed", conclusion="cancelled"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_MERGE_BLOCKED
 
@@ -277,7 +277,7 @@ class TestRunAIPRLoop:
                 ReviewInfo(id=5, user="copilot-pull-request-reviewer[bot]", state="APPROVED", body="lgtm"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.dispatch_repair.assert_not_called()
@@ -292,7 +292,7 @@ class TestRunAIPRLoop:
                 ReviewInfo(id=9, user="copilot-pull-request-reviewer[bot]", state="APPROVED", body="lgtm"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.merge_pr.assert_called_once()
@@ -307,7 +307,7 @@ class TestRunAIPRLoop:
         )
         provider.dispatch_repair.return_value = 200
         provider.list_review_comments.return_value = ["fix this"]
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_REPAIR_DISPATCHED
         provider.dispatch_repair.assert_called_once()
@@ -319,7 +319,7 @@ class TestRunAIPRLoop:
         )
         provider.dispatch_repair.return_value = 200
         provider.list_review_comments.return_value = ["suggestion: use const"]
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_REPAIR_DISPATCHED
         provider.dispatch_repair.assert_called_once()
@@ -534,7 +534,7 @@ class TestRunAIPRLoop:
             reviews=[ReviewInfo(id=3, user="copilot-pull-request-reviewer[bot]", state="COMMENTED", body="lgtm")]
         )
         provider.list_review_comments.return_value = []
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.dispatch_repair.assert_not_called()
@@ -548,7 +548,7 @@ class TestRunAIPRLoop:
                 ReviewInfo(id=8, user="copilot-pull-request-reviewer[bot]", state="APPROVED", body="lgtm"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.dispatch_repair.assert_not_called()
@@ -559,7 +559,7 @@ class TestRunAIPRLoop:
         provider = _make_provider(reviews=[ReviewInfo(id=4, user="Copilot", state="COMMENTED", body="")])
         provider.dispatch_repair.return_value = 200
         provider.list_review_comments.return_value = ["please fix this"]
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_REPAIR_DISPATCHED
         provider.dispatch_repair.assert_called_once()
@@ -572,7 +572,7 @@ class TestRunAIPRLoop:
                 ReviewInfo(id=5, user="copilot-pull-request-reviewer[bot]", state="APPROVED", body="lgtm"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.dispatch_repair.assert_not_called()
@@ -585,7 +585,7 @@ class TestRunAIPRLoop:
         )
         provider.list_review_comments.side_effect = RuntimeError("network error")
         provider.dispatch_repair.return_value = 200
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_REPAIR_DISPATCHED
         provider.dispatch_repair.assert_called_once()
@@ -599,7 +599,7 @@ class TestRunAIPRLoop:
                 ReviewInfo(id=8, user="copilot-pull-request-reviewer[bot]", state="APPROVED", body="lgtm"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.dispatch_repair.assert_not_called()
@@ -620,7 +620,7 @@ class TestRunAIPRLoop:
             ),
             files=["src/main.py"],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         # Draft review requests must only happen after squash + publish so the
@@ -661,7 +661,7 @@ class TestRunAIPRLoop:
             ),
             files=["src/main.py"],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.publish_pr.assert_not_called()
@@ -683,7 +683,7 @@ class TestRunAIPRLoop:
             ),
             files=["src/main.py"],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.publish_pr.assert_not_called()
@@ -704,7 +704,7 @@ class TestRunAIPRLoop:
             ),
             files=[],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.publish_pr.assert_not_called()
@@ -725,7 +725,7 @@ class TestRunAIPRLoop:
             ),
             reviews=[],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_not_called()
@@ -735,7 +735,7 @@ class TestRunAIPRLoop:
     def test_non_draft_pr_with_no_files_does_not_request_review(self) -> None:
         """Non-draft PRs with no changed files are treated as not ready."""
         provider = _make_provider(files=[], reviews=[])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_not_called()
@@ -758,7 +758,7 @@ class TestRunAIPRLoop:
             files=["src/main.py"],
         )
         provider.publish_pr.side_effect = RuntimeError("gh pr ready failed")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_MERGE_BLOCKED
         provider.approve_pr.assert_not_called()
@@ -780,7 +780,7 @@ class TestRunAIPRLoop:
             files=["src/main.py"],
         )
         provider.request_reviewer.side_effect = RuntimeError("request failed")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.squash_before_publish.assert_called_once()
@@ -804,7 +804,7 @@ class TestRunAIPRLoop:
             ),
             files=["src/main.py"],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.squash_before_publish.assert_called_once()
@@ -829,7 +829,7 @@ class TestRunAIPRLoop:
             files=["src/main.py"],
         )
         provider.squash_before_publish.side_effect = RuntimeError("squash failed")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_MERGE_BLOCKED
         provider.publish_pr.assert_not_called()
@@ -851,7 +851,7 @@ class TestRunAIPRLoop:
             files=["src/main.py"],
         )
         provider.squash_before_publish.side_effect = RuntimeError("squash boom")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
         assert summary.get("squash_error") == "squash boom"
         assert summary.get("decision") == "error"
@@ -861,7 +861,7 @@ class TestRunAIPRLoop:
     def test_no_copilot_review_requests_review_and_waits(self) -> None:
         """When no Copilot review exists, requests one and returns SUCCESS without merging."""
         provider = _make_provider(reviews=[])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_called_once_with(42, COPILOT_REVIEWER_LOGIN)
@@ -883,7 +883,7 @@ class TestRunAIPRLoop:
             ),
             reviews=[],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_not_called()
@@ -933,7 +933,7 @@ class TestRunAIPRLoop:
     def test_no_copilot_review_with_human_approval_still_waits(self) -> None:
         """Even with a human approval, no Copilot review means the loop waits for one."""
         provider = _make_provider(reviews=[ReviewInfo(id=1, user="reviewer", state="APPROVED", body="lgtm")])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_called_once_with(42, COPILOT_REVIEWER_LOGIN)
@@ -943,7 +943,7 @@ class TestRunAIPRLoop:
         """Review-request failures are non-blocking while waiting for initial Copilot review."""
         provider = _make_provider(reviews=[])
         provider.request_reviewer.side_effect = RuntimeError("request failed")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.approve_pr.assert_not_called()
@@ -954,7 +954,7 @@ class TestRunAIPRLoop:
         provider = _make_provider(
             reviews=[ReviewInfo(id=1, user="copilot-pull-request-reviewer[bot]", state="APPROVED", body="lgtm")]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.merge_pr.assert_called_once()
@@ -975,7 +975,7 @@ class TestRunAIPRLoop:
         provider = _make_provider(
             reviews=[ReviewInfo(id=1, user="copilot-pull-request-reviewer[bot]", state="DISMISSED", body="")]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_called_once_with(42, COPILOT_REVIEWER_LOGIN)
@@ -987,7 +987,7 @@ class TestRunAIPRLoop:
         provider = _make_provider(
             reviews=[ReviewInfo(id=1, user="copilot-pull-request-reviewer[bot]", state="PENDING", body="")]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
         assert result == EXIT_SUCCESS
         provider.request_reviewer.assert_called_once_with(42, COPILOT_REVIEWER_LOGIN)
@@ -1000,7 +1000,7 @@ class TestRunAIPRLoopDecisionSummary:
 
     def test_merged_pr_emits_summary(self) -> None:
         provider = _make_provider()
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "merged"
@@ -1031,7 +1031,7 @@ class TestRunAIPRLoopDecisionSummary:
 
     def test_pending_checks_emits_wait_summary(self) -> None:
         provider = _make_provider(check_runs=[CheckRunStatus(id=1, name="Tests ✅", status="in_progress")])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "wait"
@@ -1047,7 +1047,7 @@ class TestRunAIPRLoopDecisionSummary:
             reviews=[],
         )
         provider.dispatch_repair.return_value = 200
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "repair_dispatched"
@@ -1067,7 +1067,7 @@ class TestRunAIPRLoopDecisionSummary:
             reviews=[],
         )
         provider.dispatch_repair.return_value = 200
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
 
         with patch(
             "agentic_devtools.cli.ci.orchestrator.increment_cycle_count",
@@ -1157,7 +1157,7 @@ class TestRunAIPRLoopDecisionSummary:
             reviews=[],
         )
         provider.dispatch_repair.return_value = 200
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert "Tests ✅" in summary["ci"]["failed"]
@@ -1171,7 +1171,7 @@ class TestRunAIPRLoopDecisionSummary:
                 CheckRunStatus(id=1, name="Tests ✅", status="completed", conclusion="cancelled"),
             ]
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "blocked"
@@ -1181,7 +1181,7 @@ class TestRunAIPRLoopDecisionSummary:
     def test_pr_files_error_emits_error_summary(self) -> None:
         provider = _make_provider()
         provider.list_pr_files.side_effect = RuntimeError("api unavailable")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1195,7 +1195,7 @@ class TestRunAIPRLoopDecisionSummary:
             reviews=[],
         )
         provider.dispatch_repair.side_effect = RuntimeError("dispatch endpoint timeout")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "repair_failed"
@@ -1205,7 +1205,7 @@ class TestRunAIPRLoopDecisionSummary:
     def test_check_runs_error_emits_error_summary(self) -> None:
         provider = _make_provider()
         provider.list_check_runs.side_effect = RuntimeError("checks api unavailable")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1216,7 +1216,7 @@ class TestRunAIPRLoopDecisionSummary:
     def test_list_reviews_error_emits_error_summary(self) -> None:
         provider = _make_provider()
         provider.list_reviews.side_effect = RuntimeError("reviews api unavailable")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1230,7 +1230,7 @@ class TestRunAIPRLoopDecisionSummary:
         )
         provider.list_review_comments.return_value = []
         provider.approve_pr.side_effect = RuntimeError("approval endpoint unavailable")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1241,7 +1241,7 @@ class TestRunAIPRLoopDecisionSummary:
     def test_merge_error_emits_error_summary(self) -> None:
         provider = _make_provider()
         provider.merge_pr.side_effect = RuntimeError("merge conflict")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1252,7 +1252,7 @@ class TestRunAIPRLoopDecisionSummary:
     def test_deduplication_check_error_emits_error_summary(self) -> None:
         provider = _make_provider()
         provider.find_comment.side_effect = RuntimeError("dedup api unavailable")
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1267,7 +1267,7 @@ class TestRunAIPRLoopDecisionSummary:
             None,  # dedup: no existing marker → calls post_comment; succeeds
             RuntimeError("cycle api unavailable"),  # cycle: raises
         ]
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="synchronize")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "error"
@@ -1290,7 +1290,7 @@ class TestRunAIPRLoopDecisionSummary:
             ),
             files=["src/main.py"],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "published_awaiting_review"
@@ -1311,7 +1311,7 @@ class TestRunAIPRLoopDecisionSummary:
             ),
             files=["src/main.py"],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "draft_not_ready"
@@ -1333,7 +1333,7 @@ class TestRunAIPRLoopDecisionSummary:
             ),
             files=[],
         )
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "draft_not_ready"
@@ -1343,7 +1343,7 @@ class TestRunAIPRLoopDecisionSummary:
     def test_no_copilot_review_emits_awaiting_copilot_review_summary(self) -> None:
         """No Copilot review emits 'awaiting_copilot_review' decision in summary."""
         provider = _make_provider(reviews=[])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
         summary = _capture_summary(provider, payload)
 
         assert summary["decision"] == "awaiting_copilot_review"

--- a/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_actionable_checks.py
+++ b/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_actionable_checks.py
@@ -56,7 +56,7 @@ class TestActionableCheckNames:
             conclusion="success",
         )
         provider = _make_provider(check_runs=[ignored, passing])
-        payload = EventPayload(pr_number=42, head_sha="abc123")
+        payload = EventPayload(pr_number=42, head_sha="abc123", action="submitted")
 
         result = run_ai_pr_loop(provider, payload)
 

--- a/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_blocked.py
+++ b/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_blocked.py
@@ -3,11 +3,31 @@
 from unittest.mock import MagicMock
 
 from agentic_devtools.cli.ci.models import (
+    COPILOT_REVIEWER_LOGIN,
     CheckRunStatus,
     EventPayload,
     PRMetadata,
+    ReviewInfo,
 )
-from agentic_devtools.cli.ci.orchestrator import EXIT_REPAIR_DISPATCHED, run_ai_pr_loop
+from agentic_devtools.cli.ci.orchestrator import (
+    EXIT_GUARD_BLOCKED,
+    EXIT_REPAIR_DISPATCHED,
+    EXIT_SUCCESS,
+    run_ai_pr_loop,
+)
+
+
+def _base_pr_meta(head_sha: str = "abc456def789") -> PRMetadata:
+    return PRMetadata(
+        number=42,
+        title="feat: test",
+        head_branch="feature/test",
+        head_sha=head_sha,
+        base_branch="main",
+        head_repo_full_name="owner/repo",
+        base_repo_full_name="owner/repo",
+        labels=[],
+    )
 
 
 class TestRunAIPRLoopRepairDispatch:
@@ -19,7 +39,7 @@ class TestRunAIPRLoopRepairDispatch:
             number=42,
             title="feat: failing",
             head_branch="feature/fail",
-            head_sha="sha456",
+            head_sha="abc456def789",
             base_branch="main",
             head_repo_full_name="owner/repo",
             base_repo_full_name="owner/repo",
@@ -35,10 +55,87 @@ class TestRunAIPRLoopRepairDispatch:
         provider.post_comment.return_value = 100
         provider.dispatch_repair.return_value = 200
 
-        payload = EventPayload(pr_number=42, head_sha="sha456")
+        payload = EventPayload(pr_number=42, head_sha="abc456def789")
         result = run_ai_pr_loop(provider, payload)
 
         assert result == EXIT_REPAIR_DISPATCHED
         provider.merge_pr.assert_not_called()
         provider.approve_pr.assert_not_called()
         provider.dispatch_repair.assert_called_once()
+
+    def test_dedup_blocks_non_review_submission_when_limit_exceeded(self) -> None:
+        """Non-review-submission events (e.g. push/synchronize) are blocked by dedup."""
+        _SHA = "abc456def789"
+        provider = MagicMock()
+        provider.get_pr_metadata.return_value = _base_pr_meta(_SHA)
+        provider.list_pr_files.return_value = ["src/app.py"]
+        provider.list_check_runs.return_value = [
+            CheckRunStatus(id=1, name="Tests ✅", status="completed", conclusion="success"),
+        ]
+        # Simulate dedup counter already at max (count=3, so next increment → 4 > 3)
+        provider.find_comment.return_value = (
+            99,
+            f"<!-- repair-dispatch:{_SHA}:3 -->\nDispatch tracking for `{_SHA[:8]}`",
+        )
+
+        payload = EventPayload(pr_number=42, head_sha=_SHA, action="synchronize")
+        result = run_ai_pr_loop(provider, payload)
+
+        assert result == EXIT_GUARD_BLOCKED
+
+    def test_review_submission_bypasses_dedup_when_limit_exceeded(self) -> None:
+        """Review submission events bypass deduplication even when the dispatch limit is exceeded."""
+        _SHA = "abc456def789"
+        provider = MagicMock()
+        provider.get_pr_metadata.return_value = _base_pr_meta(_SHA)
+        provider.list_pr_files.return_value = ["src/app.py"]
+        provider.list_check_runs.return_value = [
+            CheckRunStatus(id=1, name="Tests ✅", status="completed", conclusion="success"),
+        ]
+        # Dedup counter well above limit — should be ignored for "submitted" events.
+        # Keep the mock realistic by only returning a dedup comment when the dedup
+        # marker is explicitly requested; cycle-tracker lookups should not receive a
+        # comment body for a different marker.
+        def _find_comment_side_effect(_pr_number: int, marker: str):
+            if marker == "<!-- repair-dispatch:":
+                return (
+                    99,
+                    f"<!-- repair-dispatch:{_SHA}:99 -->\nDispatch tracking for `{_SHA[:8]}`",
+                )
+            return None
+
+        provider.find_comment.side_effect = _find_comment_side_effect
+        provider.list_reviews.return_value = [
+            ReviewInfo(id=1, user=COPILOT_REVIEWER_LOGIN, state="APPROVED", body="lgtm"),
+        ]
+        provider.merge_pr.return_value = None
+
+        payload = EventPayload(pr_number=42, head_sha=_SHA, action="submitted")
+        result = run_ai_pr_loop(provider, payload)
+
+        # Should bypass dedup and continue down the success/merge path.
+        assert result == EXIT_SUCCESS
+        provider.merge_pr.assert_called_once()
+        provider.dispatch_repair.assert_not_called()
+        # check_deduplication should never have been called (find_comment only for cycle check)
+        dedup_calls = [c for c in provider.find_comment.call_args_list if c.args[1] == "<!-- repair-dispatch:"]
+        assert dedup_calls == [], f"dedup find_comment was called unexpectedly: {dedup_calls}"
+
+    def test_missing_action_does_not_bypass_dedup_when_limit_exceeded(self) -> None:
+        """Missing action should not be treated as a review submission for dedup bypass."""
+        _SHA = "abc456def789"
+        provider = MagicMock()
+        provider.get_pr_metadata.return_value = _base_pr_meta(_SHA)
+        provider.list_pr_files.return_value = ["src/app.py"]
+        provider.list_check_runs.return_value = [
+            CheckRunStatus(id=1, name="Tests ✅", status="completed", conclusion="success"),
+        ]
+        provider.find_comment.return_value = (
+            99,
+            f"<!-- repair-dispatch:{_SHA}:99 -->\nDispatch tracking for `{_SHA[:8]}`",
+        )
+
+        payload = EventPayload(pr_number=42, head_sha=_SHA)
+        result = run_ai_pr_loop(provider, payload)
+
+        assert result == EXIT_GUARD_BLOCKED

--- a/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_no_issue.py
+++ b/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_no_issue.py
@@ -37,7 +37,7 @@ class TestRunAIPRLoopNoIssue:
         provider.find_comment.return_value = None
         provider.post_comment.return_value = 100
 
-        payload = EventPayload(pr_number=99, head_sha="nnn999")
+        payload = EventPayload(pr_number=99, head_sha="nnn999", action="submitted")
         result = run_ai_pr_loop(provider, payload)
 
         assert result == EXIT_SUCCESS

--- a/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_ready.py
+++ b/tests/unit/cli/ci/orchestrator/test_run_ai_pr_loop_ready.py
@@ -39,7 +39,7 @@ class TestRunAIPRLoopReady:
         provider.post_comment.return_value = 100
         provider.merge_pr.return_value = None
 
-        payload = EventPayload(pr_number=42, head_sha="sha123")
+        payload = EventPayload(pr_number=42, head_sha="sha123", action="submitted")
         result = run_ai_pr_loop(provider, payload)
 
         assert result == EXIT_SUCCESS


### PR DESCRIPTION
fix(#1491): skip dedup guard for pull_request_review submitted events
- Guard check_deduplication behind event_payload.action == "submitted" check
- Review submissions are external triggers not caused by the repair-dispatch loop
- Prevents orchestrator from being blocked on completed reviews after budget exhaustion
- Added regression tests for both blocked and bypassed scenarios

#1491