### PR TITLE
fix(#1646): normalize PEM certs to fix malformed CA bundle on corporate proxies

### DIFF
--- a/agentic_devtools/cli/cert_utils.py
+++ b/agentic_devtools/cli/cert_utils.py
@@ -49,7 +49,7 @@ def normalize_pem(pem_content: str) -> str:
     result = pem_content
     for cert in certs:
         lines = cert.split("\n")
-        clean_lines = [l for l in lines if l.strip()]
+        clean_lines = [line for line in lines if line.strip()]
         if len(clean_lines) < len(lines):
             result = result.replace(cert, "\n".join(clean_lines))
     return result
@@ -88,17 +88,7 @@ def fetch_certificate_chain_openssl(hostname: str, port: int = 443) -> str | Non
         cert_pattern = r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"
         certs = re.findall(cert_pattern, output, re.DOTALL)
         if certs:
-            # Normalize each PEM block: remove blank lines within the base64
-            # body.  Some corporate proxies or openssl builds insert empty
-            # lines between base64 data lines, which produces malformed PEM
-            # that Python's ssl module rejects with "[X509] PEM lib".
-            normalized = []
-            for cert in certs:
-                lines = cert.split("\n")
-                # Keep BEGIN/END markers and non-empty body lines
-                clean_lines = [l for l in lines if l.strip()]
-                normalized.append("\n".join(clean_lines))
-            return "\n".join(normalized)
+            return normalize_pem("\n".join(certs))
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError, subprocess.SubprocessError):
         pass
     except Exception:  # noqa: BLE001 — cert fetch must not crash setup
@@ -218,8 +208,14 @@ def ensure_ca_bundle(
                 try:
                     cache_file.write_text(normalized, encoding="utf-8")
                 except OSError:
-                    pass  # Best-effort; file is still usable by openssl
-            return str(cache_file)
+                    # Write failed — the on-disk PEM is still malformed and
+                    # would be rejected by Python's ssl module.  Fall through
+                    # to refetch rather than returning a known-bad path.
+                    pass
+                else:
+                    return str(cache_file)
+            else:
+                return str(cache_file)
         # Stale/leaf-only cache — remove it before refetching so it doesn't
         # linger on disk and get picked up by external configs (e.g. npmrc cafile).
         try:

--- a/agentic_devtools/cli/cert_utils.py
+++ b/agentic_devtools/cli/cert_utils.py
@@ -27,6 +27,34 @@ from agentic_devtools.cli.subprocess_utils import run_safe
 _CERTS_DIR = Path.home() / ".agdt" / "certs"
 
 
+def normalize_pem(pem_content: str) -> str:
+    """Remove blank lines within PEM certificate bodies.
+
+    Some corporate proxies and openssl builds insert empty lines between
+    base64 data lines in PEM certificates.  Python's ``ssl`` module rejects
+    such malformed PEM with ``[X509] PEM lib``.  This function strips those
+    blank lines while preserving the ``BEGIN``/``END`` markers.
+
+    Args:
+        pem_content: Raw PEM string (may contain multiple certificates).
+
+    Returns:
+        Normalized PEM string with blank lines removed from certificate bodies.
+    """
+    cert_pattern = r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"
+    certs = re.findall(cert_pattern, pem_content, re.DOTALL)
+    if not certs:
+        return pem_content
+
+    result = pem_content
+    for cert in certs:
+        lines = cert.split("\n")
+        clean_lines = [l for l in lines if l.strip()]
+        if len(clean_lines) < len(lines):
+            result = result.replace(cert, "\n".join(clean_lines))
+    return result
+
+
 def fetch_certificate_chain_openssl(hostname: str, port: int = 443) -> str | None:
     """Fetch the SSL certificate chain from *hostname* using ``openssl s_client``.
 
@@ -60,7 +88,17 @@ def fetch_certificate_chain_openssl(hostname: str, port: int = 443) -> str | Non
         cert_pattern = r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"
         certs = re.findall(cert_pattern, output, re.DOTALL)
         if certs:
-            return "\n".join(certs)
+            # Normalize each PEM block: remove blank lines within the base64
+            # body.  Some corporate proxies or openssl builds insert empty
+            # lines between base64 data lines, which produces malformed PEM
+            # that Python's ssl module rejects with "[X509] PEM lib".
+            normalized = []
+            for cert in certs:
+                lines = cert.split("\n")
+                # Keep BEGIN/END markers and non-empty body lines
+                clean_lines = [l for l in lines if l.strip()]
+                normalized.append("\n".join(clean_lines))
+            return "\n".join(normalized)
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError, subprocess.SubprocessError):
         pass
     except Exception:  # noqa: BLE001 — cert fetch must not crash setup
@@ -173,6 +211,14 @@ def ensure_ca_bundle(
             # Treat unreadable or undecodable cache as missing and refetch.
             existing = ""
         if count_certificates_in_pem(existing) >= 2:
+            # Normalize in-place: remove blank lines within cert bodies that
+            # cause Python's ssl module to reject the file.
+            normalized = normalize_pem(existing)
+            if normalized != existing:
+                try:
+                    cache_file.write_text(normalized, encoding="utf-8")
+                except OSError:
+                    pass  # Best-effort; file is still usable by openssl
             return str(cache_file)
         # Stale/leaf-only cache — remove it before refetching so it doesn't
         # linger on disk and get picked up by external configs (e.g. npmrc cafile).
@@ -307,11 +353,13 @@ def ssl_request_with_retry(
         requests.RequestException: On network errors after all retries.
     """
     import requests
+    import urllib3
 
     # --no-verify-ssl override via environment variable.
     # The user has explicitly opted in by setting AGDT_NO_VERIFY_SSL (via agdt-setup --no-verify-ssl)
     # and is aware of the security implications (printed warning during setup).
     if os.environ.get("AGDT_NO_VERIFY_SSL"):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         print(
             "  ⚠  SSL verification disabled (AGDT_NO_VERIFY_SSL). Use only on trusted networks.",
             file=sys.stderr,

--- a/agentic_devtools/cli/setup/commands.py
+++ b/agentic_devtools/cli/setup/commands.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from agentic_devtools.cli.cert_utils import ensure_ca_bundle as _ensure_ca_bundle
+from agentic_devtools.cli.cert_utils import normalize_pem as _normalize_pem
 
 from .copilot_cli_installer import install_copilot_cli
 from .dependency_checker import check_all_dependencies, print_dependency_report
@@ -104,11 +105,7 @@ def _build_unified_ca_bundle(per_host_pem_paths: list[str]) -> Path | None:
         chain = re.findall(cert_pattern, content, re.DOTALL)
         # Skip index 0 (leaf/server cert); only add intermediates and roots
         for cert in chain[1:]:
-            # Normalize: remove blank lines within the base64 body.
-            # Some corporate proxies produce PEM with empty lines between
-            # base64 data lines, which Python's ssl module rejects.
-            lines = cert.split("\n")
-            cert = "\n".join(l for l in lines if l.strip())
+            cert = _normalize_pem(cert)
             if cert not in system_certs:
                 system_certs.add(cert)
                 extra_certs.append(cert)

--- a/agentic_devtools/cli/setup/commands.py
+++ b/agentic_devtools/cli/setup/commands.py
@@ -104,6 +104,11 @@ def _build_unified_ca_bundle(per_host_pem_paths: list[str]) -> Path | None:
         chain = re.findall(cert_pattern, content, re.DOTALL)
         # Skip index 0 (leaf/server cert); only add intermediates and roots
         for cert in chain[1:]:
+            # Normalize: remove blank lines within the base64 body.
+            # Some corporate proxies produce PEM with empty lines between
+            # base64 data lines, which Python's ssl module rejects.
+            lines = cert.split("\n")
+            cert = "\n".join(l for l in lines if l.strip())
             if cert not in system_certs:
                 system_certs.add(cert)
                 extra_certs.append(cert)

--- a/agentic_devtools/cli/setup/pr_workflow.py
+++ b/agentic_devtools/cli/setup/pr_workflow.py
@@ -11,6 +11,7 @@ if restoration fails.
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 from collections.abc import Callable
@@ -193,85 +194,115 @@ def run_setup_with_pr_workflow(
         has_changes = bool(status_result.stdout.strip())
 
         if has_changes:
-            # Step 7 — create branch, commit, push
-            # All git operations use check=False because the PR workflow is
-            # best-effort: a failure here must not terminate agdt-setup.
-            branch_name = _resolve_branch_name(version)
-            create_branch = run_git("checkout", "-b", branch_name, check=False)
-            if create_branch.returncode != 0:
-                print(
-                    f"Error: Could not create branch '{branch_name}': {create_branch.stderr.strip()}",
-                    file=sys.stderr,
-                )
-                message = f"Failed to create branch '{branch_name}'."
+            # Step 6b — idempotency check: stage everything and compare
+            # the resulting tree against origin/main.  If the tree is
+            # identical, the setup produced the same content that is
+            # already in main (e.g. a previous setup PR was merged).
+            run_git("add", ".", check=False)
+            staged_tree = run_git("write-tree", check=False)
+            main_tree = run_git("rev-parse", "origin/main^{tree}", check=False)
+            if (
+                staged_tree.returncode == 0
+                and main_tree.returncode == 0
+                and staged_tree.stdout.strip() == main_tree.stdout.strip()
+            ):
+                # Trees are identical — no meaningful changes.
+                run_git("reset", "HEAD", check=False)
+                message = "No new changes — setup output matches origin/main (already merged)."
             else:
-                commit_msg = f"chore: agdt-setup v{version}"
-                add_result = run_git("add", ".", check=False)
-                if add_result.returncode != 0:
+                # Reset staging so the branch creation flow re-stages cleanly.
+                run_git("reset", "HEAD", check=False)
+
+                # Step 7 — create branch, commit, push
+                # All git operations use check=False because the PR workflow is
+                # best-effort: a failure here must not terminate agdt-setup.
+                branch_name = _resolve_branch_name(version)
+                create_branch = run_git("checkout", "-b", branch_name, check=False)
+                if create_branch.returncode != 0:
                     print(
-                        f"Error: 'git add .' failed: {add_result.stderr.strip()}",
+                        f"Error: Could not create branch '{branch_name}': {create_branch.stderr.strip()}",
                         file=sys.stderr,
                     )
-                    message = "Failed to stage changes."
+                    message = f"Failed to create branch '{branch_name}'."
                 else:
-                    commit_result = run_git("commit", "-m", commit_msg, check=False)
-                    if commit_result.returncode != 0:
+                    commit_msg = f"chore: agdt-setup v{version}"
+                    add_result = run_git("add", ".", check=False)
+                    if add_result.returncode != 0:
                         print(
-                            f"Error: 'git commit' failed: {commit_result.stderr.strip()}",
+                            f"Error: 'git add .' failed: {add_result.stderr.strip()}",
                             file=sys.stderr,
                         )
-                        message = "Failed to commit changes."
+                        message = "Failed to stage changes."
                     else:
-                        branch_created = branch_name
-
-                        push_result = run_git("push", "--set-upstream", "origin", branch_name, check=False)
-                        if push_result.returncode != 0:
+                        commit_result = run_git("commit", "-m", commit_msg, check=False)
+                        if commit_result.returncode != 0:
                             print(
-                                f"Error: Failed to push branch '{branch_name}': {push_result.stderr.strip()}",
+                                f"Error: 'git commit' failed: {commit_result.stderr.strip()}",
                                 file=sys.stderr,
                             )
-                            message = f"Branch '{branch_name}' created and committed but push failed."
+                            message = "Failed to commit changes."
                         else:
-                            # Step 8 — create PR synchronously
-                            try:
-                                from agentic_devtools.cli.azure_devops.commands import (
-                                    create_pull_request,
+                            branch_created = branch_name
+
+                            push_result = run_git("push", "--set-upstream", "origin", branch_name, check=False)
+                            if push_result.returncode != 0:
+                                print(
+                                    f"Error: Failed to push branch '{branch_name}': {push_result.stderr.strip()}",
+                                    file=sys.stderr,
                                 )
-                                from agentic_devtools.state import get_value, set_value
-
-                                # Preserve existing state so we can restore it
-                                prev_source_branch = get_value("source_branch")
-                                prev_title = get_value("title")
-                                prev_draft = get_value("draft")
-
+                                message = f"Branch '{branch_name}' created and committed but push failed."
+                            else:
+                                # Step 8 — create PR synchronously
                                 try:
-                                    pr_title = f"chore: agdt-setup v{version}"
-                                    set_value("source_branch", branch_name)
-                                    set_value("title", pr_title)
-                                    set_value("draft", "false")
+                                    from agentic_devtools.cli.azure_devops.commands import (
+                                        create_pull_request,
+                                    )
+                                    from agentic_devtools.state import get_value, set_value
 
-                                    create_pull_request()
-                                    pr_created = True
-                                    message = f"PR created from branch '{branch_name}'."
-                                finally:
-                                    # Restore prior values (None when previously unset)
-                                    set_value("source_branch", prev_source_branch)
-                                    set_value("title", prev_title)
-                                    set_value("draft", prev_draft)
-                            except SystemExit as exc:
-                                # create_pull_request() calls sys.exit() on
-                                # validation/az failures — treat as non-fatal.
-                                print(
-                                    f"Warning: PR creation failed ({exc}) — branch '{branch_name}' was pushed.",
-                                    file=sys.stderr,
-                                )
-                                message = f"Branch '{branch_name}' pushed but PR creation failed."
-                            except Exception as exc:  # noqa: BLE001
-                                print(
-                                    f"Warning: PR creation failed ({exc}) — branch '{branch_name}' was pushed.",
-                                    file=sys.stderr,
-                                )
-                                message = f"Branch '{branch_name}' pushed but PR creation failed."
+                                    # Preserve existing state so we can restore it
+                                    prev_source_branch = get_value("source_branch")
+                                    prev_title = get_value("title")
+                                    prev_draft = get_value("draft")
+
+                                    # Propagate SSL verification disable to az CLI
+                                    # so PR creation works on corporate networks.
+                                    prev_az_ssl = os.environ.get("AZURE_CLI_DISABLE_CONNECTION_VERIFICATION")
+                                    if os.environ.get("AGDT_NO_VERIFY_SSL"):
+                                        os.environ["AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"] = "1"
+
+                                    try:
+                                        pr_title = f"chore: agdt-setup v{version}"
+                                        set_value("source_branch", branch_name)
+                                        set_value("title", pr_title)
+                                        set_value("draft", "false")
+
+                                        create_pull_request()
+                                        pr_created = True
+                                        message = f"PR created from branch '{branch_name}'."
+                                    finally:
+                                        # Restore prior values (None when previously unset)
+                                        set_value("source_branch", prev_source_branch)
+                                        set_value("title", prev_title)
+                                        set_value("draft", prev_draft)
+                                        # Restore az CLI SSL state
+                                        if prev_az_ssl is None:
+                                            os.environ.pop("AZURE_CLI_DISABLE_CONNECTION_VERIFICATION", None)
+                                        else:
+                                            os.environ["AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"] = prev_az_ssl
+                                except SystemExit as exc:
+                                    # create_pull_request() calls sys.exit() on
+                                    # validation/az failures — treat as non-fatal.
+                                    print(
+                                        f"Warning: PR creation failed ({exc}) — branch '{branch_name}' was pushed.",
+                                        file=sys.stderr,
+                                    )
+                                    message = f"Branch '{branch_name}' pushed but PR creation failed."
+                                except Exception as exc:  # noqa: BLE001
+                                    print(
+                                        f"Warning: PR creation failed ({exc}) — branch '{branch_name}' was pushed.",
+                                        file=sys.stderr,
+                                    )
+                                    message = f"Branch '{branch_name}' pushed but PR creation failed."
     finally:
         # Step 12 — restore original branch
         restore = run_git("checkout", original_branch, check=False)

--- a/agentic_devtools/cli/setup/pr_workflow.py
+++ b/agentic_devtools/cli/setup/pr_workflow.py
@@ -198,20 +198,23 @@ def run_setup_with_pr_workflow(
             # the resulting tree against origin/main.  If the tree is
             # identical, the setup produced the same content that is
             # already in main (e.g. a previous setup PR was merged).
-            run_git("add", ".", check=False)
-            staged_tree = run_git("write-tree", check=False)
-            main_tree = run_git("rev-parse", "origin/main^{tree}", check=False)
-            if (
-                staged_tree.returncode == 0
-                and main_tree.returncode == 0
-                and staged_tree.stdout.strip() == main_tree.stdout.strip()
-            ):
-                # Trees are identical — no meaningful changes.
-                run_git("reset", "HEAD", check=False)
+            idempotent = False
+            add_result = run_git("add", ".", check=False)
+            if add_result.returncode == 0:
+                staged_tree = run_git("write-tree", check=False)
+                main_tree = run_git("rev-parse", "origin/main^{tree}", check=False)
+                if (
+                    staged_tree.returncode == 0
+                    and main_tree.returncode == 0
+                    and staged_tree.stdout.strip() == main_tree.stdout.strip()
+                ):
+                    idempotent = True
+            # Always reset the index after the idempotency probe so the
+            # branch creation flow can re-stage cleanly.
+            run_git("reset", "HEAD", check=False)
+            if idempotent:
                 message = "No new changes — setup output matches origin/main (already merged)."
             else:
-                # Reset staging so the branch creation flow re-stages cleanly.
-                run_git("reset", "HEAD", check=False)
 
                 # Step 7 — create branch, commit, push
                 # All git operations use check=False because the PR workflow is
@@ -280,15 +283,18 @@ def run_setup_with_pr_workflow(
                                         pr_created = True
                                         message = f"PR created from branch '{branch_name}'."
                                     finally:
-                                        # Restore prior values (None when previously unset)
-                                        set_value("source_branch", prev_source_branch)
-                                        set_value("title", prev_title)
-                                        set_value("draft", prev_draft)
-                                        # Restore az CLI SSL state
+                                        # Restore az CLI SSL state FIRST — before
+                                        # potentially failing state writes so a
+                                        # set_value() I/O error cannot leave SSL
+                                        # verification disabled for the process.
                                         if prev_az_ssl is None:
                                             os.environ.pop("AZURE_CLI_DISABLE_CONNECTION_VERIFICATION", None)
                                         else:
                                             os.environ["AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"] = prev_az_ssl
+                                        # Restore prior state values (None when previously unset)
+                                        set_value("source_branch", prev_source_branch)
+                                        set_value("title", prev_title)
+                                        set_value("draft", prev_draft)
                                 except SystemExit as exc:
                                     # create_pull_request() calls sys.exit() on
                                     # validation/az failures — treat as non-fatal.

--- a/tests/unit/cli/cert_utils/test_ensure_ca_bundle.py
+++ b/tests/unit/cli/cert_utils/test_ensure_ca_bundle.py
@@ -23,6 +23,62 @@ class TestEnsureCaBundle:
 
         assert result == str(cache_file)
 
+    def test_rewrites_cached_file_when_pem_has_blank_lines(self, tmp_path):
+        """Rewrites cached file in-place when PEM bodies contain blank lines."""
+        malformed_chain = (
+            "-----BEGIN CERTIFICATE-----\n\nserver\n\n-----END CERTIFICATE-----\n"
+            "-----BEGIN CERTIFICATE-----\n\nca\n\n-----END CERTIFICATE-----"
+        )
+        cache_file = tmp_path / "example.com.pem"
+        cache_file.write_text(malformed_chain, encoding="utf-8")
+
+        result = cert_utils.ensure_ca_bundle("example.com", cache_file=cache_file)
+
+        assert result == str(cache_file)
+        # File must be rewritten with normalized content (no blank lines in bodies)
+        content = cache_file.read_text(encoding="utf-8")
+        assert "\n\n" not in content
+        assert "-----BEGIN CERTIFICATE-----" in content
+        assert "server" in content
+        assert "ca" in content
+
+    def test_cache_rewrite_oserror_falls_through_to_refetch(self, tmp_path):
+        """Falls through to refetch when the normalize rewrite fails with OSError.
+
+        When the in-place normalization write fails, the on-disk PEM is still
+        malformed.  Rather than returning a known-bad path, the function must
+        fall through to refetch so callers never receive a path to a file that
+        Python's ssl module would reject.
+        """
+        malformed_chain = (
+            "-----BEGIN CERTIFICATE-----\n\nserver\n\n-----END CERTIFICATE-----\n"
+            "-----BEGIN CERTIFICATE-----\n\nca\n\n-----END CERTIFICATE-----"
+        )
+        complete_chain = (
+            "-----BEGIN CERTIFICATE-----\nserver\n-----END CERTIFICATE-----\n"
+            "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"
+        )
+        cache_file = tmp_path / "example.com.pem"
+        cache_file.write_text(malformed_chain, encoding="utf-8")
+
+        call_count = {"n": 0}
+        original_write_text = type(cache_file).write_text
+
+        def _fail_first_write(self, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError("disk full")
+            return original_write_text(self, *args, **kwargs)
+
+        with patch.object(type(cache_file), "write_text", _fail_first_write):
+            with patch.object(cert_utils, "fetch_certificate_chain_openssl", return_value=complete_chain):
+                result = cert_utils.ensure_ca_bundle("example.com", cache_file=cache_file)
+
+        # The refetch succeeds and writes the clean chain
+        assert result == str(cache_file.resolve())
+        content = cache_file.read_text(encoding="utf-8")
+        assert "\n\n" not in content
+
     def test_fetches_and_saves_when_cache_missing(self, tmp_path):
         """Fetches and saves the cert chain when no cache file exists."""
         complete_chain = (

--- a/tests/unit/cli/cert_utils/test_normalize_pem.py
+++ b/tests/unit/cli/cert_utils/test_normalize_pem.py
@@ -1,0 +1,81 @@
+"""Tests for normalize_pem."""
+
+from agentic_devtools.cli import cert_utils
+
+
+class TestNormalizePem:
+    """Tests for normalize_pem."""
+
+    def test_returns_input_unchanged_when_no_certificates(self):
+        """Returns the input string unchanged when no PEM certificate blocks are found."""
+        content = "not a certificate"
+        assert cert_utils.normalize_pem(content) == content
+
+    def test_returns_empty_string_unchanged(self):
+        """Returns an empty string unchanged."""
+        assert cert_utils.normalize_pem("") == ""
+
+    def test_valid_pem_without_blank_lines_is_unchanged(self):
+        """A well-formed PEM block with no blank lines is returned unchanged."""
+        pem = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIB1TCCAb2gAwIBAgIJAKl\n"
+            "base64datahere==\n"
+            "-----END CERTIFICATE-----"
+        )
+        assert cert_utils.normalize_pem(pem) == pem
+
+    def test_blank_lines_inside_certificate_body_are_removed(self):
+        """Blank lines inside a PEM certificate body are stripped."""
+        pem_with_blanks = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIB1TCCAb2g\n"
+            "\n"
+            "base64datahere==\n"
+            "\n"
+            "-----END CERTIFICATE-----"
+        )
+        expected = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIB1TCCAb2g\n"
+            "base64datahere==\n"
+            "-----END CERTIFICATE-----"
+        )
+        assert cert_utils.normalize_pem(pem_with_blanks) == expected
+
+    def test_multiple_certificates_are_each_normalized(self):
+        """Blank lines are removed from each certificate block in a multi-cert PEM."""
+        pem = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "cert1line1\n"
+            "\n"
+            "cert1line2\n"
+            "-----END CERTIFICATE-----\n"
+            "-----BEGIN CERTIFICATE-----\n"
+            "cert2line1\n"
+            "\n"
+            "cert2line2\n"
+            "-----END CERTIFICATE-----"
+        )
+        result = cert_utils.normalize_pem(pem)
+        # Both certs should be normalized: no blank lines within their bodies
+        assert "\n\n" not in result
+        assert "cert1line1\ncert1line2" in result
+        assert "cert2line1\ncert2line2" in result
+
+    def test_whitespace_only_lines_inside_body_are_removed(self):
+        """Lines containing only whitespace inside a certificate body are removed."""
+        pem_with_whitespace = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "base64data\n"
+            "   \n"
+            "moredata==\n"
+            "-----END CERTIFICATE-----"
+        )
+        expected = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "base64data\n"
+            "moredata==\n"
+            "-----END CERTIFICATE-----"
+        )
+        assert cert_utils.normalize_pem(pem_with_whitespace) == expected

--- a/tests/unit/cli/setup/pr_workflow/test_run_setup_with_pr_workflow.py
+++ b/tests/unit/cli/setup/pr_workflow/test_run_setup_with_pr_workflow.py
@@ -39,6 +39,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok("stash@{0}\n"),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M some-file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify (branch not taken locally)
                 _ok(""),  # ls-remote (branch not taken remotely)
                 _ok(),  # checkout -b branch
@@ -91,6 +95,35 @@ class TestRunSetupWithPrWorkflow:
         assert result["branch_created"] is None
         assert result["pr_created"] is False
         assert "No file changes" in result["message"]
+        setup_fn.assert_called_once()
+
+    # ── Idempotency: tree matches origin/main ──────────────────────────
+
+    def test_idempotent_run_skips_branch_when_tree_matches_main(self):
+        """When staged tree matches origin/main tree, skip branch creation."""
+        setup_fn = MagicMock()
+
+        with patch(_RUN_GIT) as mock_git:
+            mock_git.side_effect = [
+                _ok(),  # fetch origin main
+                _ok("main\n"),  # rev-parse --abbrev-ref HEAD
+                _ok(""),  # stash list (before)
+                _ok(),  # stash push
+                _ok(""),  # stash list (after)
+                _ok(),  # checkout origin/main --detach
+                _ok(" M file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("same_tree_hash\n"),  # write-tree
+                _ok("same_tree_hash\n"),  # rev-parse origin/main^{tree} (SAME)
+                _ok(),  # reset HEAD (unstage)
+                _ok(),  # checkout original branch (finally)
+            ]
+            result = run_setup_with_pr_workflow(setup_fn, "1.0.0")
+
+        assert result["success"] is True
+        assert result["branch_created"] is None
+        assert result["pr_created"] is False
+        assert "already merged" in result["message"]
         setup_fn.assert_called_once()
 
     # ── Fetch failure → fallback ───────────────────────────────────────
@@ -198,6 +231,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok(""),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _ok(),  # rev-parse --verify base → taken
                 _fail(),  # rev-parse --verify -2 → free
                 _ok(""),  # ls-remote -2 → free
@@ -229,6 +266,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok("stash@{0}\n"),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b
@@ -267,6 +308,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok("stash@{0}\n"),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b
@@ -311,6 +356,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok("stash@{0}\n"),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b
@@ -345,6 +394,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok("stash@{0}\n"),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b
@@ -384,6 +437,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok("stash@{0}\n"),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b
@@ -737,6 +794,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok(""),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _fail("already exists"),  # checkout -b FAILS
@@ -767,6 +828,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok(""),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b
@@ -797,6 +862,10 @@ class TestRunSetupWithPrWorkflow:
                 _ok(""),  # stash list (after)
                 _ok(),  # checkout origin/main --detach
                 _ok(" M file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
                 _fail(),  # rev-parse --verify → free
                 _ok(""),  # ls-remote → free
                 _ok(),  # checkout -b

--- a/tests/unit/cli/setup/pr_workflow/test_run_setup_with_pr_workflow.py
+++ b/tests/unit/cli/setup/pr_workflow/test_run_setup_with_pr_workflow.py
@@ -1,5 +1,6 @@
 """Tests for run_setup_with_pr_workflow."""
 
+import os
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock, patch
 
@@ -881,3 +882,137 @@ class TestRunSetupWithPrWorkflow:
 
         err = capsys.readouterr().err
         assert "git commit" in err
+
+    # ── Idempotency add failure ────────────────────────────────────────
+
+    def test_idempotency_add_failure_falls_through_to_branch_flow(self, capsys):
+        """When the idempotency 'git add .' fails, skip the tree comparison and proceed to branch creation."""
+        setup_fn = MagicMock()
+
+        with patch(_RUN_GIT) as mock_git:
+            mock_git.side_effect = [
+                _ok(),  # fetch origin main
+                _ok("main\n"),  # rev-parse --abbrev-ref HEAD
+                _ok(""),  # stash list (before)
+                _ok(),  # stash push
+                _ok(""),  # stash list (after)
+                _ok(),  # checkout origin/main --detach
+                _ok(" M file.txt\n"),  # status --porcelain (has changes)
+                _fail("permission denied"),  # add . (idempotency probe FAILS)
+                _ok(),  # reset HEAD (always called after probe)
+                _fail(),  # rev-parse --verify → branch free
+                _ok(""),  # ls-remote → branch free
+                _ok(),  # checkout -b branch
+                _fail("permission denied"),  # add . (branch flow also fails)
+                _ok(),  # checkout original (finally)
+            ]
+            result = run_setup_with_pr_workflow(setup_fn, "1.0.0")
+
+        assert result["success"] is True
+        assert result["branch_created"] is None
+        assert result["pr_created"] is False
+        # Must NOT report "already merged"; must have fallen through to branch flow
+        assert "already merged" not in result["message"]
+        assert "Failed to stage" in result["message"]
+
+        err = capsys.readouterr().err
+        assert "git add" in err
+
+    # ── SSL env var propagation ────────────────────────────────────────
+
+    def test_no_verify_ssl_sets_azure_cli_env_var_during_pr_creation(self):
+        """AGDT_NO_VERIFY_SSL=1 sets AZURE_CLI_DISABLE_CONNECTION_VERIFICATION=1 during create_pull_request()."""
+        setup_fn = MagicMock()
+        captured: dict[str, str | None] = {}
+
+        def _capture_env():
+            captured["during"] = os.environ.get("AZURE_CLI_DISABLE_CONNECTION_VERIFICATION")
+
+        with patch(_RUN_GIT) as mock_git:
+            mock_git.side_effect = [
+                _ok(),  # fetch origin main
+                _ok("main\n"),  # rev-parse --abbrev-ref HEAD
+                _ok(""),  # stash list (before)
+                _ok(),  # stash push
+                _ok("stash@{0}\n"),  # stash list (after)
+                _ok(),  # checkout origin/main --detach
+                _ok(" M some-file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
+                _fail(),  # rev-parse --verify (branch free)
+                _ok(""),  # ls-remote (branch free)
+                _ok(),  # checkout -b branch
+                _ok(),  # add .
+                _ok(),  # commit
+                _ok(),  # push
+                _ok(),  # checkout original branch (finally)
+                _ok(),  # stash pop (finally)
+            ]
+            # Ensure AZURE_CLI_DISABLE_CONNECTION_VERIFICATION is absent before the run,
+            # and AGDT_NO_VERIFY_SSL is set.
+            clean_env = {
+                k: v
+                for k, v in os.environ.items()
+                if k != "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"
+            }
+            clean_env["AGDT_NO_VERIFY_SSL"] = "1"
+            with patch.dict(os.environ, clean_env, clear=True):
+                with patch(_CREATE_PR, side_effect=_capture_env):
+                    with patch(_SET_VALUE):
+                        with patch(_GET_VALUE, return_value=None):
+                            result = run_setup_with_pr_workflow(setup_fn, "1.0.0")
+
+                # After the call, the var must be restored (removed since it was absent).
+                assert "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION" not in os.environ
+
+        assert result["pr_created"] is True
+        assert captured.get("during") == "1"
+
+    def test_no_verify_ssl_restores_prior_azure_cli_env_var(self):
+        """AZURE_CLI_DISABLE_CONNECTION_VERIFICATION is restored to its prior value after PR creation."""
+        setup_fn = MagicMock()
+        captured: dict[str, str | None] = {}
+
+        def _capture_env():
+            captured["during"] = os.environ.get("AZURE_CLI_DISABLE_CONNECTION_VERIFICATION")
+
+        with patch(_RUN_GIT) as mock_git:
+            mock_git.side_effect = [
+                _ok(),  # fetch origin main
+                _ok("main\n"),  # rev-parse --abbrev-ref HEAD
+                _ok(""),  # stash list (before)
+                _ok(),  # stash push
+                _ok("stash@{0}\n"),  # stash list (after)
+                _ok(),  # checkout origin/main --detach
+                _ok(" M some-file.txt\n"),  # status --porcelain (has changes)
+                _ok(),  # add . (idempotency staging)
+                _ok("aaa111\n"),  # write-tree
+                _ok("bbb222\n"),  # rev-parse origin/main^{tree} (different)
+                _ok(),  # reset HEAD (unstage)
+                _fail(),  # rev-parse --verify (branch free)
+                _ok(""),  # ls-remote (branch free)
+                _ok(),  # checkout -b branch
+                _ok(),  # add .
+                _ok(),  # commit
+                _ok(),  # push
+                _ok(),  # checkout original branch (finally)
+                _ok(),  # stash pop (finally)
+            ]
+            env_overrides = {
+                "AGDT_NO_VERIFY_SSL": "1",
+                "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION": "existing-value",
+            }
+            with patch.dict(os.environ, env_overrides):
+                with patch(_CREATE_PR, side_effect=_capture_env):
+                    with patch(_SET_VALUE):
+                        with patch(_GET_VALUE, return_value=None):
+                            result = run_setup_with_pr_workflow(setup_fn, "1.0.0")
+
+                # Prior value must be restored after the call.
+                assert os.environ.get("AZURE_CLI_DISABLE_CONNECTION_VERIFICATION") == "existing-value"
+
+        assert result["pr_created"] is True
+        # The var was already set to "existing-value"; AGDT_NO_VERIFY_SSL overwrites it to "1".
+        assert captured.get("during") == "1"


### PR DESCRIPTION
## Summary

Fixes #1646

On corporate networks where a TLS-intercepting proxy re-signs certificates, `openssl s_client -showcerts` output contains blank lines between base64 data lines. These get captured into PEM cache files, producing an invalid unified CA bundle that Python's ssl module rejects with `[X509] PEM lib (_ssl.c:4353)`.

## Changes

- **cert_utils.py** — Added `normalize_pem()` function that strips blank lines from within PEM certificate bodies. Applied at fetch time and cache-read time.
- **setup/commands.py** — Applied normalization when reading per-host PEM files during `_build_unified_ca_bundle()`.
- **setup/pr_workflow.py** — Added git tree-comparison idempotency check (skips if changes already in main), AZURE_CLI_DISABLE_CONNECTION_VERIFICATION propagation, and urllib3.disable_warnings() for --no-verify-ssl.
- **test_run_setup_with_pr_workflow.py** — Updated tests for new git commands, added test_skips_when_tree_matches_main.

## Testing

- 96 unit tests pass for modified files
- End-to-end verified: agdt-setup in target repo successfully created PR #28269 (Azure DevOps)
- InsecureRequestWarning suppression verified (0 warnings with --no-verify-ssl)
