### PR TITLE
fix(#1742): remove stale auto-start task before starting Copilot session

### DIFF
--- a/agentic_devtools/cli/workflows/commands.py
+++ b/agentic_devtools/cli/workflows/commands.py
@@ -394,6 +394,17 @@ Examples:
     clear_state_for_workflow_initiation(preserve_run_id=bool(skip_copilot_session))
     set_value("copilot.model_id", model)
 
+    # Remove any stale VS Code auto-start task from a previous workflow to
+    # prevent a duplicate Copilot session from firing on folderOpen/reload.
+    # This is belt-and-suspenders alongside the cleanup in
+    # _start_copilot_session_for_workflow — the earlier we remove the stale
+    # task, the smaller the window for a race where VS Code reloads and fires
+    # the old task before we start the new session.
+    repo_root_early = get_git_repo_root() or os.getcwd()
+    from .worktree_setup import _cleanup_stale_auto_start_task_for_worktree
+
+    _cleanup_stale_auto_start_task_for_worktree(repo_root_early)
+
     # Set provided values in state using the NORMALIZED identifiers.  When both issue_key
     # and pull_request_id are provided, write jira.issue_key FIRST so that the engine-side
     # priority guard in set_value() (which checks the loaded state dict) sees the issue key

--- a/agentic_devtools/cli/workflows/worktree_setup.py
+++ b/agentic_devtools/cli/workflows/worktree_setup.py
@@ -1456,6 +1456,27 @@ def _remove_stale_auto_start_task(
     remove_auto_start_task(tasks_path, vscode_dir, task_label, delete_if_empty=delete_if_empty)
 
 
+def _cleanup_stale_auto_start_task_for_worktree(worktree_path: str) -> None:
+    """Remove any stale auto-start task from a worktree's ``.vscode/tasks.json``.
+
+    Best-effort helper that derives the paths from *worktree_path* and
+    delegates to :func:`_remove_stale_auto_start_task`.  Called before
+    starting a new Copilot session to prevent a leftover ``runOn: folderOpen``
+    task from a previous workflow from spawning a duplicate session when
+    VS Code reloads.
+
+    All errors are silently caught so this never prevents the caller from
+    proceeding.
+    """
+    try:
+        vscode_dir = os.path.join(worktree_path, ".vscode")
+        tasks_path = os.path.join(vscode_dir, "tasks.json")
+        if os.path.isfile(tasks_path):
+            _remove_stale_auto_start_task(tasks_path, vscode_dir, _AUTO_START_TASK_LABEL)
+    except Exception:
+        pass
+
+
 class WorktreeStateContext:
     """Context manager for cross-worktree state resolution.
 
@@ -2468,6 +2489,12 @@ def _start_copilot_session_for_workflow(
         )
 
     effective_interactive = interactive and is_vscode_available() and has_tty
+
+    # Remove any stale auto-start task from tasks.json BEFORE starting a new
+    # session. A leftover runOn:folderOpen task from a previous workflow
+    # invocation can fire when VS Code reloads, causing a duplicate Copilot
+    # session alongside the one we are about to start. See #1742.
+    _cleanup_stale_auto_start_task_for_worktree(worktree_path)
 
     print(
         f"\n--- Starting gh copilot session for {workflow_name} "

--- a/tests/unit/cli/workflows/worktree_setup/test__cleanup_stale_auto_start_task_for_worktree.py
+++ b/tests/unit/cli/workflows/worktree_setup/test__cleanup_stale_auto_start_task_for_worktree.py
@@ -1,0 +1,105 @@
+"""Tests for _cleanup_stale_auto_start_task_for_worktree."""
+
+import json
+from unittest.mock import patch
+
+import agentic_devtools.cli.workflows.worktree_setup as _ws_module
+from agentic_devtools.cli.workflows.worktree_setup import (
+    _AUTO_START_TASK_LABEL,
+    _cleanup_stale_auto_start_task_for_worktree,
+)
+
+
+class TestCleanupStaleAutoStartTaskForWorktree:
+    """Tests for the _cleanup_stale_auto_start_task_for_worktree helper."""
+
+    def test_removes_stale_task_from_tasks_json(self, tmp_path):
+        """Should remove the auto-start task when tasks.json exists."""
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        tasks_path = vscode_dir / "tasks.json"
+        tasks_data = {
+            "version": "2.0.0",
+            "tasks": [
+                {
+                    "label": _AUTO_START_TASK_LABEL,
+                    "type": "shell",
+                    "command": "echo stale",
+                    "runOptions": {"runOn": "folderOpen"},
+                },
+                {
+                    "label": "other-task",
+                    "type": "shell",
+                    "command": "echo keep",
+                },
+            ],
+        }
+        tasks_path.write_text(json.dumps(tasks_data), encoding="utf-8")
+
+        _cleanup_stale_auto_start_task_for_worktree(str(tmp_path))
+
+        result = json.loads(tasks_path.read_text(encoding="utf-8"))
+        labels = [t["label"] for t in result["tasks"]]
+        assert _AUTO_START_TASK_LABEL not in labels
+        assert "other-task" in labels
+
+    def test_no_op_when_tasks_json_missing(self, tmp_path):
+        """Should not raise when .vscode/tasks.json does not exist."""
+        _cleanup_stale_auto_start_task_for_worktree(str(tmp_path))
+
+    def test_no_op_when_vscode_dir_missing(self, tmp_path):
+        """Should not raise when .vscode directory does not exist."""
+        nonexistent = str(tmp_path / "nonexistent_worktree")
+        _cleanup_stale_auto_start_task_for_worktree(nonexistent)
+
+    def test_no_op_when_no_matching_task(self, tmp_path):
+        """Should leave tasks.json unchanged when no auto-start task present."""
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        tasks_path = vscode_dir / "tasks.json"
+        tasks_data = {
+            "version": "2.0.0",
+            "tasks": [
+                {"label": "build", "type": "shell", "command": "make"},
+            ],
+        }
+        tasks_path.write_text(json.dumps(tasks_data), encoding="utf-8")
+
+        _cleanup_stale_auto_start_task_for_worktree(str(tmp_path))
+
+        result = json.loads(tasks_path.read_text(encoding="utf-8"))
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["label"] == "build"
+
+    def test_silently_handles_invalid_json(self, tmp_path):
+        """Should not raise when tasks.json contains invalid JSON."""
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        tasks_path = vscode_dir / "tasks.json"
+        tasks_path.write_text("not valid json {{{", encoding="utf-8")
+
+        # Should not raise
+        _cleanup_stale_auto_start_task_for_worktree(str(tmp_path))
+
+    def test_silently_handles_unexpected_exception(self, tmp_path):
+        """Should not raise when an unexpected error occurs (e.g. OS error on isfile)."""
+        with patch.object(_ws_module.os.path, "isfile", side_effect=OSError("boom")):
+            # Should not raise despite the OSError
+            _cleanup_stale_auto_start_task_for_worktree(str(tmp_path))
+
+    def test_delegates_to_remove_stale_auto_start_task(self, tmp_path):
+        """Should call _remove_stale_auto_start_task with correct paths."""
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        tasks_path = vscode_dir / "tasks.json"
+        tasks_data = {"version": "2.0.0", "tasks": []}
+        tasks_path.write_text(json.dumps(tasks_data), encoding="utf-8")
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup._remove_stale_auto_start_task") as mock_remove:
+            _cleanup_stale_auto_start_task_for_worktree(str(tmp_path))
+
+        mock_remove.assert_called_once_with(
+            str(tasks_path),
+            str(vscode_dir),
+            _AUTO_START_TASK_LABEL,
+        )


### PR DESCRIPTION
## Summary

Fixes #1742

Removes stale \unOn: folderOpen\ auto-start tasks from \.vscode/tasks.json\ before starting a new Copilot session, preventing duplicate sessions.

## Changes

- **\worktree_setup.py\**: Added \_cleanup_stale_auto_start_task_for_worktree()\ helper + call in \_start_copilot_session_for_workflow()\
- **\commands.py\**: Early cleanup call in \initiate_pull_request_review_workflow()\ after state clearing
- **New test file**: 6 unit tests for the new helper

## Root Cause

A leftover auto-start task from a previous workflow (e.g., \create-jira-issue\) fires when VS Code reloads the workspace. Since \copilot.auto_start_triggered_runs\ is empty after state reset, deduplication doesn't prevent it, causing a second Copilot session.

## Testing

- All 27 tests in \	est__start_copilot_session_for_workflow.py\ pass
- All 391 tests in \	est_initiate_pull_request_review_workflow.py\ pass
- All 6 new tests pass