### PR TITLE
fix(#1744): scope pre-push mypy check to only changed files

### DIFF
--- a/agentic_devtools/cli/checks/lint.py
+++ b/agentic_devtools/cli/checks/lint.py
@@ -71,7 +71,7 @@ def mypy_check_files(files: list[str], *, cwd: str | None = None) -> tuple[bool,
     if not files:
         return True, ""
     result = subprocess.run(
-        ["mypy", "--ignore-missing-imports"] + files,
+        ["mypy", "--ignore-missing-imports", "--follow-imports=silent"] + files,
         cwd=cwd,
         capture_output=True,
         text=True,

--- a/tests/unit/cli/checks/lint/test_mypy_check_files.py
+++ b/tests/unit/cli/checks/lint/test_mypy_check_files.py
@@ -42,3 +42,10 @@ class TestMypyCheckFiles:
         mypy_check_files(["a.py"])
         args = mock_run.call_args[0][0]
         assert "--ignore-missing-imports" in args
+
+    @patch(f"{MODULE}.subprocess.run")
+    def test_passes_follow_imports_silent(self, mock_run):
+        mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        mypy_check_files(["a.py"])
+        args = mock_run.call_args[0][0]
+        assert "--follow-imports=silent" in args


### PR DESCRIPTION
## Summary

Fixes #1744

Adds \--follow-imports=silent\ to the mypy invocation in the pre-push hook's targeted checks. This ensures mypy only reports errors from the explicitly passed (changed) files, not from transitively imported modules.

## Problem

Previously, changing 3 files could produce \Found 122 errors in 21 files (checked 3 source files)\ because mypy follows imports and reports errors from all reachable modules.

## Changes

- **\lint.py\**: Added \--follow-imports=silent\ flag to \mypy_check_files()\
- **\	est_mypy_check_files.py\**: Added test verifying the new flag is passed

## How it works

\--follow-imports=silent\ tells mypy to:
- Still resolve types from imported modules (preserving type-checking accuracy)
- Suppress error reporting from those imported modules
- Only report errors in the explicitly listed files