### PR TITLE
fix(#1746): delete stale prompt file before spawning PR review setup

### DIFF
--- a/agentic_devtools/cli/workflows/commands.py
+++ b/agentic_devtools/cli/workflows/commands.py
@@ -602,12 +602,37 @@ Examples:
     else:
         # Normal interactive path: spawn setup in background and start
         # a Copilot session that waits for the prompt file.
+
+        # Delete any stale prompt file from a previous review so that
+        # _wait_for_prompt_file() doesn't return immediately before the
+        # new background setup has completed.  See #1746.
+        from .worktree_setup import _WORKFLOW_PROMPT_FILENAMES
+
+        _stale_prompt = resolved_state_dir / _WORKFLOW_PROMPT_FILENAMES["pull-request-review"]
+        _stale_prompt_cleared = True
+        if _stale_prompt.is_file():
+            try:
+                _stale_prompt.unlink(missing_ok=True)
+            except OSError as exc:
+                print(f"WARNING: Failed to delete stale prompt file {_stale_prompt}: {exc}")
+                _stale_prompt_cleared = False
+        elif _stale_prompt.exists():
+            print(f"WARNING: Stale prompt path exists but is not a regular file: {_stale_prompt}")
+            _stale_prompt_cleared = False
+
         from ..azure_devops.async_commands import setup_pull_request_review_async
 
         setup_pull_request_review_async(
             pull_request_id=int(resolved_pr_id),
             jira_issue_key=resolved_issue_key,
         )
+
+        if not _stale_prompt_cleared:
+            print(
+                "WARNING: Skipping Copilot session start — stale prompt file could not be "
+                "removed. Re-run once the path is writable."
+            )
+            return
 
         from .worktree_setup import _start_copilot_session_for_pr_review
 

--- a/tests/unit/cli/workflows/commands/test_initiate_pull_request_review_workflow.py
+++ b/tests/unit/cli/workflows/commands/test_initiate_pull_request_review_workflow.py
@@ -1105,3 +1105,185 @@ class TestSkipCopilotSession:
         mocks["async_setup"].assert_called_once()
         mocks["sync_setup"].assert_not_called()
         mocks["session"].assert_called_once()
+
+    def test_stale_prompt_file_deleted_before_async_setup(
+        self, temp_state_dir, clear_state_before, mock_workflow_state_clearing, monkeypatch
+    ):
+        """A leftover prompt file from a previous review is deleted before spawning async setup."""
+        from agentic_devtools.cli.workflows.preflight import PreflightResult
+
+        monkeypatch.setenv("AGENTIC_DEVTOOLS_STATE_DIR", str(temp_state_dir))
+        state.set_value("pull_request_id", "999")
+
+        # Create a stale prompt file simulating a previous review run
+        stale_prompt = temp_state_dir / "temp-pull-request-review-initiate-prompt.md"
+        stale_prompt.write_text("stale content from previous review", encoding="utf-8")
+        assert stale_prompt.exists()
+
+        def _assert_stale_removed_before_async_setup(*_args, **_kwargs):
+            assert not stale_prompt.exists()
+
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers.get_pull_request_source_branch",
+            return_value="feature/some-branch",
+        ):
+            with patch(
+                "agentic_devtools.cli.azure_devops.helpers.find_jira_issue_from_pr",
+                return_value=None,
+            ):
+                with patch("agentic_devtools.cli.workflows.commands.check_worktree_and_branch") as mock_preflight:
+                    mock_preflight.return_value = PreflightResult(
+                        folder_valid=True,
+                        branch_valid=True,
+                        folder_name="PR999",
+                        branch_name="feature/some-branch",
+                        issue_key=None,
+                    )
+                    with patch(
+                        "agentic_devtools.cli.workflows.commands.get_git_repo_root",
+                        return_value="/fake/repo-root",
+                    ):
+                        with patch(
+                            "agentic_devtools.cli.azure_devops.async_commands.setup_pull_request_review_async",
+                            side_effect=_assert_stale_removed_before_async_setup,
+                        ) as mock_async_setup:
+                            with patch(
+                                "agentic_devtools.cli.workflows.worktree_setup._start_copilot_session_for_pr_review",
+                                return_value=True,
+                            ):
+                                with patch(
+                                    "agentic_devtools.cli.workflows.commands.get_default_copilot_model",
+                                    return_value="gpt-4o",
+                                ):
+                                    commands.initiate_pull_request_review_workflow(
+                                        skip_copilot_session=False,
+                                        _argv=[],
+                                    )
+
+        mock_async_setup.assert_called_once()
+
+    def test_directory_at_stale_prompt_path_prints_warning(
+        self, temp_state_dir, clear_state_before, mock_workflow_state_clearing, monkeypatch, capsys
+    ):
+        """A directory at the stale prompt path logs a warning without crashing."""
+        from agentic_devtools.cli.workflows.preflight import PreflightResult
+
+        monkeypatch.setenv("AGENTIC_DEVTOOLS_STATE_DIR", str(temp_state_dir))
+        state.set_value("pull_request_id", "999")
+
+        # Place a directory where the prompt file would normally be
+        stale_dir = temp_state_dir / "temp-pull-request-review-initiate-prompt.md"
+        stale_dir.mkdir()
+        assert stale_dir.is_dir()
+
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers.get_pull_request_source_branch",
+            return_value="feature/some-branch",
+        ):
+            with patch(
+                "agentic_devtools.cli.azure_devops.helpers.find_jira_issue_from_pr",
+                return_value=None,
+            ):
+                with patch("agentic_devtools.cli.workflows.commands.check_worktree_and_branch") as mock_preflight:
+                    mock_preflight.return_value = PreflightResult(
+                        folder_valid=True,
+                        branch_valid=True,
+                        folder_name="PR999",
+                        branch_name="feature/some-branch",
+                        issue_key=None,
+                    )
+                    with patch(
+                        "agentic_devtools.cli.workflows.commands.get_git_repo_root",
+                        return_value="/fake/repo-root",
+                    ):
+                        with patch(
+                            "agentic_devtools.cli.azure_devops.async_commands.setup_pull_request_review_async"
+                        ) as mock_async_setup:
+                            with patch(
+                                "agentic_devtools.cli.workflows.worktree_setup._start_copilot_session_for_pr_review",
+                                return_value=True,
+                            ) as mock_session:
+                                with patch(
+                                    "agentic_devtools.cli.workflows.commands.get_default_copilot_model",
+                                    return_value="gpt-4o",
+                                ):
+                                    commands.initiate_pull_request_review_workflow(
+                                        skip_copilot_session=False,
+                                        _argv=[],
+                                    )
+
+        mock_async_setup.assert_called_once()
+        mock_session.assert_not_called()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "temp-pull-request-review-initiate-prompt.md" in captured.out
+        # The directory must not be removed
+        assert stale_dir.is_dir()
+
+    def test_stale_prompt_unlink_error_skips_copilot_session(
+        self, temp_state_dir, clear_state_before, mock_workflow_state_clearing, monkeypatch, capsys
+    ):
+        """A stale prompt unlink error warns, still runs async setup, but skips the Copilot session."""
+        import pathlib
+
+        from agentic_devtools.cli.workflows.preflight import PreflightResult
+
+        monkeypatch.setenv("AGENTIC_DEVTOOLS_STATE_DIR", str(temp_state_dir))
+        state.set_value("pull_request_id", "999")
+        stale_prompt = temp_state_dir / "temp-pull-request-review-initiate-prompt.md"
+        stale_prompt.write_text("stale content from previous review", encoding="utf-8")
+        assert stale_prompt.is_file()
+        original_unlink = pathlib.Path.unlink
+
+        def _unlink(path_obj, *args, **kwargs):
+            if path_obj == stale_prompt:
+                raise PermissionError("permission denied")
+            return original_unlink(path_obj, *args, **kwargs)
+
+        with patch(
+            "agentic_devtools.cli.azure_devops.helpers.get_pull_request_source_branch",
+            return_value="feature/some-branch",
+        ):
+            with patch(
+                "agentic_devtools.cli.azure_devops.helpers.find_jira_issue_from_pr",
+                return_value=None,
+            ):
+                with patch("agentic_devtools.cli.workflows.commands.check_worktree_and_branch") as mock_preflight:
+                    mock_preflight.return_value = PreflightResult(
+                        folder_valid=True,
+                        branch_valid=True,
+                        folder_name="PR999",
+                        branch_name="feature/some-branch",
+                        issue_key=None,
+                    )
+                    with patch(
+                        "agentic_devtools.cli.workflows.commands.get_git_repo_root",
+                        return_value="/fake/repo-root",
+                    ):
+                        with patch(
+                            "pathlib.Path.unlink",
+                            autospec=True,
+                            side_effect=_unlink,
+                        ):
+                            with patch(
+                                "agentic_devtools.cli.azure_devops.async_commands.setup_pull_request_review_async"
+                            ) as mock_async_setup:
+                                with patch(
+                                    "agentic_devtools.cli.workflows.worktree_setup._start_copilot_session_for_pr_review",
+                                    return_value=True,
+                                ) as mock_session:
+                                    with patch(
+                                        "agentic_devtools.cli.workflows.commands.get_default_copilot_model",
+                                        return_value="gpt-4o",
+                                    ):
+                                        commands.initiate_pull_request_review_workflow(
+                                            skip_copilot_session=False,
+                                            _argv=[],
+                                        )
+
+        mock_async_setup.assert_called_once()
+        mock_session.assert_not_called()
+        captured = capsys.readouterr()
+        assert "WARNING: Failed to delete stale prompt file" in captured.out
+        assert "temp-pull-request-review-initiate-prompt.md" in captured.out
+        assert "Skipping Copilot session start" in captured.out


### PR DESCRIPTION
## Summary

When re-running the PR review workflow in a worktree that has already had it executed once, the Copilot session would start immediately because `_wait_for_prompt_file()` found the leftover prompt file from the previous run.

## Changes

- Delete `temp-pull-request-review-initiate-prompt.md` from the state directory **before** spawning `setup_pull_request_review_async()`, ensuring the file-watch mechanism only succeeds after fresh setup completes.
- If the stale file cannot be removed (e.g. `PermissionError`) or a directory exists at the prompt path, `setup_pull_request_review_async()` still runs but the Copilot session start is **skipped** with an actionable WARNING, preventing the session from starting with stale context. The user can re-run once the path is writable.
- Add regression tests covering: stale file deleted before async setup, directory at prompt path, and unlink failure skipping the Copilot session start.

## Testing

All 44 tests in the affected test file pass.