### PR TITLE
Upgrade github-copilot-sdk to v1 - take 2

### DIFF
--- a/.github/scripts/speckit-trigger/copilot_generate.py
+++ b/.github/scripts/speckit-trigger/copilot_generate.py
@@ -17,26 +17,37 @@ Exit Codes:
 
 import asyncio
 import os
+import subprocess
 import sys
 
 try:
-    from copilot import CopilotClient, SubprocessConfig
+    from copilot import CopilotClient
     from copilot.session import PermissionHandler
-except Exception as first_exc:
-    try:
-        from copilot import CopilotClient  # noqa: F811
-        from copilot.config import SubprocessConfig  # type: ignore[no-redef]  # noqa: F811
-        from copilot.session import PermissionHandler  # noqa: F811
-    except Exception as fallback_exc:
-        error = first_exc if not isinstance(first_exc, ImportError) else fallback_exc
-        print(f"Error: Copilot SDK import failed: {error}", file=sys.stderr)
-        print(
-            "The 'github-copilot-sdk' package is a required dependency of agentic-devtools. "
-            "Reinstall with: python -m pip install agentic-devtools "
-            "(or 'python -m pip install .' if running from a repository checkout)",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+except Exception as exc:
+    pip_show = subprocess.run(
+        [sys.executable, "-m", "pip", "show", "github-copilot-sdk"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    pip_show_wrong = subprocess.run(
+        [sys.executable, "-m", "pip", "show", "copilot"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(f"Error: Copilot SDK import failed: {exc}", file=sys.stderr)
+    sdk_info = (pip_show.stdout or pip_show.stderr or "").strip() or "(not installed)"
+    wrong_info = (pip_show_wrong.stdout or pip_show_wrong.stderr or "").strip() or "(not installed)"
+    print(f"pip show github-copilot-sdk:\n{sdk_info}", file=sys.stderr)
+    print(f"pip show copilot:\n{wrong_info}", file=sys.stderr)
+    if wrong_info != "(not installed)" and "Package(s) not found" not in wrong_info:
+        print("⚠ Conflicting 'copilot' package detected (it may shadow github-copilot-sdk).", file=sys.stderr)
+    print(
+        "Ensure 'github-copilot-sdk' is installed and no conflicting 'copilot' package is present.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 async def main() -> int:
@@ -69,7 +80,7 @@ async def main() -> int:
     client = None
     session = None
     try:
-        client = CopilotClient(SubprocessConfig(github_token=token))
+        client = CopilotClient(github_token=token)
         await client.start()
 
         try:

--- a/agentic_devtools/cli/ci/github_provider.py
+++ b/agentic_devtools/cli/ci/github_provider.py
@@ -1519,22 +1519,13 @@ class GitHubActionsProvider(CIPlatformProvider):
 
         try:
             from copilot import CopilotClient
-            from copilot import SubprocessConfig as _CopilotSubprocessConfig
             from copilot.session import PermissionHandler
-
-            copilot_subprocess_config_cls = _CopilotSubprocessConfig
-        except Exception as primary_exc:
-            try:
-                from copilot import CopilotClient
-
-                copilot_subprocess_config_cls = importlib.import_module("copilot.config").SubprocessConfig
-                from copilot.session import PermissionHandler
-            except Exception as exc:  # pragma: no cover - optional dependency/runtime
-                logger.warning(
-                    "Copilot SDK unavailable for squash commit message generation: %s",
-                    primary_exc if not isinstance(primary_exc, ImportError) else exc,
-                )
-                return None
+        except Exception as exc:  # pragma: no cover - optional dependency/runtime
+            logger.warning(
+                "Copilot SDK unavailable for squash commit message generation: %s",
+                exc,
+            )
+            return None
 
         model = os.environ.get("COPILOT_MODEL", "claude-opus-4.6")
         unique_subjects = [subject.strip() for subject in commit_subjects if subject.strip()]
@@ -1554,7 +1545,7 @@ class GitHubActionsProvider(CIPlatformProvider):
             error_messages: list[str] = []
             done = asyncio.Event()
             try:
-                client = CopilotClient(copilot_subprocess_config_cls(github_token=token))
+                client = CopilotClient(github_token=token)
                 await client.start()
                 try:
                     session = await client.create_session(
@@ -1639,22 +1630,13 @@ class GitHubActionsProvider(CIPlatformProvider):
 
         try:
             from copilot import CopilotClient
-            from copilot import SubprocessConfig as _CopilotSubprocessConfig
             from copilot.session import PermissionHandler
-
-            copilot_subprocess_config_cls = _CopilotSubprocessConfig
-        except Exception as primary_exc:
-            try:
-                from copilot import CopilotClient
-
-                copilot_subprocess_config_cls = importlib.import_module("copilot.config").SubprocessConfig
-                from copilot.session import PermissionHandler
-            except Exception as exc:  # pragma: no cover - optional dependency/runtime
-                logger.warning(
-                    "Copilot SDK unavailable for conflict resolution: %s",
-                    primary_exc if not isinstance(primary_exc, ImportError) else exc,
-                )
-                return None
+        except Exception as exc:  # pragma: no cover - optional dependency/runtime
+            logger.warning(
+                "Copilot SDK unavailable for conflict resolution: %s",
+                exc,
+            )
+            return None
 
         model = os.environ.get("COPILOT_MODEL", "claude-opus-4.6")
         prompt = (
@@ -1676,7 +1658,7 @@ class GitHubActionsProvider(CIPlatformProvider):
             error_messages: list[str] = []
             done = asyncio.Event()
             try:
-                client = CopilotClient(copilot_subprocess_config_cls(github_token=token))
+                client = CopilotClient(github_token=token)
                 await client.start()
                 try:
                     session = await client.create_session(
@@ -2694,24 +2676,13 @@ class GitHubActionsProvider(CIPlatformProvider):
 
         try:
             from copilot import CopilotClient
-            from copilot import SubprocessConfig as _CopilotSubprocessConfig
             from copilot.session import PermissionHandler
-
-            copilot_subprocess_config_cls = _CopilotSubprocessConfig
-        except Exception as primary_exc:
-            try:
-                from copilot import CopilotClient
-
-                copilot_subprocess_config_cls = importlib.import_module("copilot.config").SubprocessConfig
-                from copilot.session import PermissionHandler
-            except Exception as exc:
-                logger.warning(
-                    "Copilot SDK unavailable for comment verification: %s",
-                    primary_exc if not isinstance(primary_exc, ImportError) else exc,
-                )
-                return {
-                    comment.id: VerificationVerdict.COMMENT_UNRESOLVE for comment, _diff_context in normalized_comments
-                }
+        except Exception as exc:
+            logger.warning(
+                "Copilot SDK unavailable for comment verification: %s",
+                exc,
+            )
+            return {comment.id: VerificationVerdict.COMMENT_UNRESOLVE for comment, _diff_context in normalized_comments}
 
         model = os.environ.get("COPILOT_MODEL", "claude-opus-4.6")
 
@@ -2719,7 +2690,7 @@ class GitHubActionsProvider(CIPlatformProvider):
             client = None
             session = None
             try:
-                client = CopilotClient(copilot_subprocess_config_cls(github_token=token))
+                client = CopilotClient(github_token=token)
                 await client.start()
                 try:
                     session = await client.create_session(
@@ -2825,19 +2796,10 @@ class GitHubActionsProvider(CIPlatformProvider):
 
         try:
             from copilot import CopilotClient
-            from copilot import SubprocessConfig as _CopilotSubprocessConfig
             from copilot.session import PermissionHandler
-
-            copilot_subprocess_config_cls = _CopilotSubprocessConfig
-        except Exception as primary_exc:
-            try:
-                from copilot import CopilotClient
-
-                copilot_subprocess_config_cls = importlib.import_module("copilot.config").SubprocessConfig
-                from copilot.session import PermissionHandler
-            except Exception as exc:
-                error = primary_exc if not isinstance(primary_exc, ImportError) else exc
-                raise RuntimeError(f"Copilot SDK unavailable: {error}") from error
+        except Exception as exc:
+            error = exc
+            raise RuntimeError(f"Copilot SDK unavailable: {error}") from error
 
         selected_model = model or os.environ.get("COPILOT_MODEL", "claude-opus-4.6")
 
@@ -2849,7 +2811,7 @@ class GitHubActionsProvider(CIPlatformProvider):
             done = asyncio.Event()
 
             try:
-                client = CopilotClient(copilot_subprocess_config_cls(github_token=token))
+                client = CopilotClient(github_token=token)
                 await client.start()
                 try:
                     session = await client.create_session(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "langgraph-checkpoint-sqlite>=3.0.1",
     "mcp>=1.0.0",
     "packaging>=21.0",
-    "github-copilot-sdk>=0.1.0,<1.0.0",
+    "github-copilot-sdk>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/cli/ci/github_provider/test__generate_commit_message_via_sdk.py
+++ b/tests/unit/cli/ci/github_provider/test__generate_commit_message_via_sdk.py
@@ -55,59 +55,11 @@ def _build_sdk_mocks(
 
     mock_copilot = MagicMock()
     mock_copilot.CopilotClient.return_value = mock_client
-    mock_copilot.SubprocessConfig = MagicMock()
 
     mock_session_module = MagicMock()
     mock_session_module.PermissionHandler = MagicMock()
 
     return mock_copilot, mock_session_module, mock_session
-
-
-def _build_sdk_mocks_no_subprocess_config(
-    events: list[tuple[str, str | None]] | None = None,
-) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
-    """Build mocks where SubprocessConfig is missing from copilot but present in copilot.config.
-
-    Returns (mock_copilot, mock_copilot_config, mock_session_module, mock_session).
-    ``mock_copilot`` has spec=['CopilotClient'] so accessing SubprocessConfig raises AttributeError,
-    which Python converts to ImportError when doing ``from copilot import SubprocessConfig``.
-    """
-    mock_session = MagicMock()
-    mock_session.disconnect = AsyncMock()
-
-    captured_callback: list = []
-
-    def capture_on(cb: object) -> None:
-        captured_callback.append(cb)
-
-    mock_session.on = MagicMock(side_effect=capture_on)
-
-    _events = events or [("assistant.message", "feat: fallback"), ("session.idle", None)]
-
-    async def fire_events(prompt: str) -> None:  # noqa: ARG001
-        cb = captured_callback[0]
-        for ev_type, ev_content in _events:
-            cb(_make_event(ev_type, ev_content))
-
-    mock_session.send = fire_events
-
-    mock_client = MagicMock()
-    mock_client.start = AsyncMock()
-    mock_client.stop = AsyncMock()
-    mock_client.create_session = AsyncMock(return_value=mock_session)
-
-    # copilot module WITHOUT SubprocessConfig (spec limits accessible attributes)
-    mock_copilot = MagicMock(spec=["CopilotClient"])
-    mock_copilot.CopilotClient.return_value = mock_client
-
-    # copilot.config module WITH SubprocessConfig
-    mock_copilot_config = MagicMock()
-    mock_copilot_config.SubprocessConfig = MagicMock()
-
-    mock_session_module = MagicMock()
-    mock_session_module.PermissionHandler = MagicMock()
-
-    return mock_copilot, mock_copilot_config, mock_session_module, mock_session
 
 
 class TestGenerateCommitMessageViaSdk:
@@ -154,7 +106,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = fire_events_and_return
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -181,7 +136,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = fire_idle_only
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -210,7 +168,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = fire_error_event
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -238,7 +199,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = send_without_events
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()):
                 provider = GitHubActionsProvider(repo="owner/repo")
                 result = provider._generate_commit_message_via_sdk(
@@ -259,7 +223,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_copilot.CopilotClient.return_value.start = hang_on_start
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -274,7 +241,9 @@ class TestGenerateCommitMessageViaSdk:
     def test_sdk_github_token_type_error_falls_back(self, monkeypatch: object) -> None:
         """Older SDK that doesn't accept github_token kwarg; fallback create_session used."""
         monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")  # type: ignore[attr-defined]
-        mock_copilot, mock_session_module, mock_session = _build_sdk_mocks(create_session_fallback=True)
+        mock_copilot, mock_session_module, mock_session = _build_sdk_mocks(
+            create_session_fallback=True,
+        )
 
         captured_callback: list = []
 
@@ -290,7 +259,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = fire_events_and_return
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -322,7 +294,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = fire_fenced_message
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -350,7 +325,10 @@ class TestGenerateCommitMessageViaSdk:
 
         mock_session.send = fire_conversational_message
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._generate_commit_message_via_sdk(
                 head_sha="abc123",
@@ -358,26 +336,3 @@ class TestGenerateCommitMessageViaSdk:
             )
 
         assert result is None
-
-    # ── Fallback import (copilot.config.SubprocessConfig) ────────────────────
-
-    def test_sdk_fallback_import_path_succeeds(self, monkeypatch: object) -> None:
-        """When SubprocessConfig is absent from copilot, falls back to copilot.config."""
-        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")  # type: ignore[attr-defined]
-        mock_copilot, mock_copilot_config, mock_session_module, _ = _build_sdk_mocks_no_subprocess_config()
-
-        with patch.dict(
-            sys.modules,
-            {
-                "copilot": mock_copilot,
-                "copilot.config": mock_copilot_config,
-                "copilot.session": mock_session_module,
-            },
-        ):
-            provider = GitHubActionsProvider(repo="owner/repo")
-            result = provider._generate_commit_message_via_sdk(
-                head_sha="abc123",
-                commit_subjects=["feat: fallback"],
-            )
-
-        assert result == "feat: fallback"

--- a/tests/unit/cli/ci/github_provider/test__resolve_conflicted_file_content_via_sdk.py
+++ b/tests/unit/cli/ci/github_provider/test__resolve_conflicted_file_content_via_sdk.py
@@ -47,55 +47,11 @@ def _build_sdk_mocks(
 
     mock_copilot = MagicMock()
     mock_copilot.CopilotClient.return_value = mock_client
-    mock_copilot.SubprocessConfig = MagicMock()
 
     mock_session_module = MagicMock()
     mock_session_module.PermissionHandler = MagicMock()
 
     return mock_copilot, mock_session_module, mock_session
-
-
-def _build_sdk_mocks_no_subprocess_config() -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
-    """Return (mock_copilot, mock_copilot_config, mock_session_module, mock_session).
-
-    ``mock_copilot`` has spec=['CopilotClient'] so that accessing SubprocessConfig raises
-    AttributeError, which Python converts to ImportError during ``from copilot import SubprocessConfig``.
-    SubprocessConfig is available on mock_copilot_config instead.
-    """
-    mock_session = MagicMock()
-    mock_session.disconnect = AsyncMock()
-
-    captured_callback: list = []
-
-    def capture_on(cb: object) -> None:
-        captured_callback.append(cb)
-
-    mock_session.on = MagicMock(side_effect=capture_on)
-
-    async def fire_events(prompt: str) -> None:  # noqa: ARG001
-        cb = captured_callback[0]
-        cb(_make_event("assistant.message", "resolved via fallback\n"))
-        cb(_make_event("session.idle"))
-
-    mock_session.send = fire_events
-
-    mock_client = MagicMock()
-    mock_client.start = AsyncMock()
-    mock_client.stop = AsyncMock()
-    mock_client.create_session = AsyncMock(return_value=mock_session)
-
-    # copilot module WITHOUT SubprocessConfig
-    mock_copilot = MagicMock(spec=["CopilotClient"])
-    mock_copilot.CopilotClient.return_value = mock_client
-
-    # copilot.config module WITH SubprocessConfig
-    mock_copilot_config = MagicMock()
-    mock_copilot_config.SubprocessConfig = MagicMock()
-
-    mock_session_module = MagicMock()
-    mock_session_module.PermissionHandler = MagicMock()
-
-    return mock_copilot, mock_copilot_config, mock_session_module, mock_session
 
 
 class TestResolveConflictedFileContentViaSdk:
@@ -146,7 +102,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = fire_events
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._resolve_conflicted_file_content_via_sdk(
                 file_path="src/main.py",
@@ -178,7 +137,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = fire_fenced
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._resolve_conflicted_file_content_via_sdk(
                 file_path="src/main.py",
@@ -209,7 +171,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = fire_incomplete_fence
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._resolve_conflicted_file_content_via_sdk(
                 file_path="src/main.py",
@@ -240,7 +205,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = fire_idle_only
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._resolve_conflicted_file_content_via_sdk(
                 file_path="src/main.py",
@@ -271,7 +239,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = fire_error
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._resolve_conflicted_file_content_via_sdk(
                 file_path="src/main.py",
@@ -301,7 +272,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = never_completes
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()):
                 provider = GitHubActionsProvider(repo="owner/repo")
                 result = provider._resolve_conflicted_file_content_via_sdk(
@@ -319,7 +293,9 @@ class TestResolveConflictedFileContentViaSdk:
     def test_sdk_github_token_type_error_falls_back(self, monkeypatch: object) -> None:
         """Older SDK that rejects github_token kwarg falls back to call without it."""
         monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")  # type: ignore[attr-defined]
-        mock_copilot, mock_session_module, mock_session = _build_sdk_mocks(create_session_fallback=True)
+        mock_copilot, mock_session_module, mock_session = _build_sdk_mocks(
+            create_session_fallback=True,
+        )
 
         captured_callback: list = []
 
@@ -335,7 +311,10 @@ class TestResolveConflictedFileContentViaSdk:
 
         mock_session.send = fire_events
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._resolve_conflicted_file_content_via_sdk(
                 file_path="src/main.py",
@@ -346,28 +325,3 @@ class TestResolveConflictedFileContentViaSdk:
 
         assert result == "resolved content\n"
         assert mock_copilot.CopilotClient.return_value.create_session.call_count == 2
-
-    # ── Fallback import (copilot.config.SubprocessConfig) ────────────────────
-
-    def test_sdk_fallback_import_path_succeeds(self, monkeypatch: object) -> None:
-        """When SubprocessConfig is absent from copilot, falls back to copilot.config."""
-        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")  # type: ignore[attr-defined]
-        mock_copilot, mock_copilot_config, mock_session_module, _ = _build_sdk_mocks_no_subprocess_config()
-
-        with patch.dict(
-            sys.modules,
-            {
-                "copilot": mock_copilot,
-                "copilot.config": mock_copilot_config,
-                "copilot.session": mock_session_module,
-            },
-        ):
-            provider = GitHubActionsProvider(repo="owner/repo")
-            result = provider._resolve_conflicted_file_content_via_sdk(
-                file_path="src/main.py",
-                conflict_content="<<<<<<< HEAD\nmine\n=======\ntheirs\n>>>>>>> branch\n",
-                base_branch="main",
-                head_branch="feature/test",
-            )
-
-        assert result == "resolved via fallback\n"

--- a/tests/unit/cli/ci/github_provider/test_finalize_post_repair.py
+++ b/tests/unit/cli/ci/github_provider/test_finalize_post_repair.py
@@ -40,53 +40,12 @@ def _build_sdk_modules() -> tuple[MagicMock, MagicMock, MagicMock]:
 
     mock_copilot = MagicMock()
     mock_copilot.CopilotClient.return_value = mock_client
-    mock_copilot.SubprocessConfig = MagicMock()
 
     mock_session_module = MagicMock()
     mock_session_module.PermissionHandler = MagicMock()
     mock_session_module.PermissionHandler.approve_all = object()
 
     return mock_copilot, mock_session_module, mock_session
-
-
-def _build_sdk_modules_no_subprocess_config(response: str) -> tuple[MagicMock, MagicMock, MagicMock]:
-    """Return (mock_copilot, mock_copilot_config, mock_session_module) where SubprocessConfig
-    is absent from copilot but present in copilot.config, to exercise the fallback import path."""
-    mock_session = MagicMock()
-    mock_session.disconnect = AsyncMock()
-
-    callbacks: list = []
-
-    def capture_on(cb: object) -> None:
-        callbacks.append(cb)
-
-    mock_session.on = MagicMock(side_effect=capture_on)
-
-    async def send_and_emit(_: str) -> None:
-        callback = callbacks[0]
-        callback(_make_sdk_event("assistant.message", response))
-        callback(_make_sdk_event("session.idle"))
-
-    mock_session.send = send_and_emit
-
-    mock_client = MagicMock()
-    mock_client.start = AsyncMock()
-    mock_client.stop = AsyncMock()
-    mock_client.create_session = AsyncMock(return_value=mock_session)
-
-    # copilot module WITHOUT SubprocessConfig (spec limits attribute access)
-    mock_copilot = MagicMock(spec=["CopilotClient"])
-    mock_copilot.CopilotClient.return_value = mock_client
-
-    # copilot.config WITH SubprocessConfig
-    mock_copilot_config = MagicMock()
-    mock_copilot_config.SubprocessConfig = MagicMock()
-
-    mock_session_module = MagicMock()
-    mock_session_module.PermissionHandler = MagicMock()
-    mock_session_module.PermissionHandler.approve_all = object()
-
-    return mock_copilot, mock_copilot_config, mock_session_module
 
 
 def _build_sdk_client_for_response(response: str) -> tuple[MagicMock, MagicMock]:
@@ -114,7 +73,6 @@ def _build_sdk_client_for_response(response: str) -> tuple[MagicMock, MagicMock]
 
     mock_copilot = MagicMock()
     mock_copilot.CopilotClient.return_value = mock_client
-    mock_copilot.SubprocessConfig = MagicMock()
 
     mock_session_module = MagicMock()
     mock_session_module.PermissionHandler = MagicMock()
@@ -750,7 +708,10 @@ class TestFinalizePostRepair:
 
         mock_session.send = send_and_emit
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._verify_comments_via_sdk(
                 [
@@ -761,7 +722,7 @@ class TestFinalizePostRepair:
 
         assert result[101] == VerificationVerdict.COMMENT_RESOLVE
         assert result[202] == VerificationVerdict.COMMENT_UNRESOLVE
-        assert mock_copilot.SubprocessConfig.call_args.kwargs["github_token"] == "test-token"
+        assert mock_copilot.CopilotClient.call_args.kwargs["github_token"] == "test-token"
 
     @patch.object(GitHubActionsProvider, "_verify_comments_via_tiered_engine")
     def test_verify_comments_via_sdk_with_head_sha_uses_tiered_engine_for_legacy_tuples(self, mock_verify) -> None:
@@ -1235,31 +1196,14 @@ class TestFinalizePostRepair:
         monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")  # type: ignore[attr-defined]
         mock_copilot, mock_session_module, _mock_session = _build_sdk_modules()
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             with patch("agentic_devtools.cli.ci.github_provider.asyncio.run", side_effect=RuntimeError("boom")):
                 provider = GitHubActionsProvider(repo="owner/repo")
                 with pytest.raises(RuntimeError, match="boom"):
                     provider._run_prompt_via_sdk("prompt")
-
-    def test_run_prompt_via_sdk_fallback_import_path_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When SubprocessConfig is absent from copilot, falls back to copilot.config."""
-        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")  # type: ignore[attr-defined]
-        mock_copilot, mock_copilot_config, mock_session_module = _build_sdk_modules_no_subprocess_config(
-            "COMMENT_RESOLVE"
-        )
-
-        with patch.dict(
-            sys.modules,
-            {
-                "copilot": mock_copilot,
-                "copilot.config": mock_copilot_config,
-                "copilot.session": mock_session_module,
-            },
-        ):
-            provider = GitHubActionsProvider(repo="owner/repo")
-            result = provider._run_prompt_via_sdk("prompt")
-
-        assert result == "COMMENT_RESOLVE"
 
     def test_run_prompt_via_sdk_fallback_uses_default_fallback_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("COPILOT_FALLBACK_MODEL", raising=False)
@@ -1304,12 +1248,15 @@ class TestFinalizePostRepair:
 
         mock_session.send = send_and_emit
 
-        with patch.dict(sys.modules, {"copilot": mock_copilot, "copilot.session": mock_session_module}):
+        with patch.dict(
+            sys.modules,
+            {"copilot": mock_copilot, "copilot.session": mock_session_module},
+        ):
             provider = GitHubActionsProvider(repo="owner/repo")
             result = provider._verify_comment_via_sdk("Comment one", "diff --git a/a.py b/a.py\n+fix")
 
         assert result == VerificationVerdict.COMMENT_RESOLVE
-        assert mock_copilot.SubprocessConfig.call_args.kwargs["github_token"] == "test-token"
+        assert mock_copilot.CopilotClient.call_args.kwargs["github_token"] == "test-token"
 
     @patch("agentic_devtools.cli.ci.github_provider._gh_api")
     def test_dispatch_repair_uses_token_and_returns_comment_id(self, mock_gh_api) -> None:

--- a/tests/workflows/test_copilot_generate.py
+++ b/tests/workflows/test_copilot_generate.py
@@ -85,12 +85,18 @@ class TestMainFunction:
 
     @pytest.fixture(autouse=True)
     def _mock_copilot_sdk(self):
-        """Provide fake ``copilot`` and ``copilot.session`` packages so the script can be imported."""
+        """Provide fake copilot packages so the script can be imported."""
         fake_copilot = MagicMock()
         fake_copilot_session = MagicMock()
         # PermissionHandler.approve_all needs to be a callable sentinel
         fake_copilot_session.PermissionHandler.approve_all = MagicMock(name="approve_all")
-        with patch.dict(sys.modules, {"copilot": fake_copilot, "copilot.session": fake_copilot_session}):
+        with patch.dict(
+            sys.modules,
+            {
+                "copilot": fake_copilot,
+                "copilot.session": fake_copilot_session,
+            },
+        ):
             yield fake_copilot, fake_copilot_session
 
     def test_empty_stdin_returns_1(self, _mock_copilot_sdk):
@@ -583,4 +589,4 @@ class TestImportFailurePath:
         assert exc_info.value.code == 1
         stderr_output = stderr_buf.getvalue()
         assert "Copilot SDK import failed" in stderr_output
-        assert "python -m pip install agentic-devtools" in stderr_output
+        assert "github-copilot-sdk" in stderr_output


### PR DESCRIPTION
Removes `SubprocessConfig` entirely (which no longer exists in v1.0.0) and uses the new v1 SDK API where `CopilotClient` accepts `github_token` directly as a keyword argument.

## Root cause of previous failure

The first attempt (#1945) assumed `SubprocessConfig` moved to `copilot.config`, but `github-copilot-sdk` v1.0.0 removed both `SubprocessConfig` and the `copilot.config` module entirely. The CI failure was:
```
ModuleNotFoundError: No module named 'copilot.config'
```

## Changes

- **`pyproject.toml`**: `"github-copilot-sdk>=0.1.0,<1.0.0"` → `"github-copilot-sdk>=1.0.0,<2.0.0"`
- **`github_provider.py`** (4 call sites): Replace `CopilotClient(SubprocessConfig(github_token=token))` with `CopilotClient(github_token=token)`
- **`copilot_generate.py`**: Same API migration
- **CI workflows** (`ai-pr-loop.yml`, `speckit-phase-progression.yml`): Updated install constraints and smoke-check lines (removed `copilot.config` import)
- **Tests**: Removed `mock_copilot_config` / `copilot.config` from `sys.modules` patches, updated assertions to check `CopilotClient` kwargs directly

## v1 import paths

```python
from copilot import CopilotClient          # unchanged
from copilot.session import PermissionHandler  # unchanged
# SubprocessConfig removed — use CopilotClient(github_token=token) directly
```

## Verification

- Installed `github-copilot-sdk==1.0.0` and confirmed `copilot.config` does not exist
- Confirmed `CopilotClient(github_token="token")` instantiates successfully
- CI smoke-check import line passes: `from copilot import CopilotClient; from copilot.session import PermissionHandler`
- All 12,383 tests pass with 100% coverage