### PR TITLE
feat: auto-delete source branch after merge in ai-pr-loop

### DIFF
--- a/agentic_devtools/cli/ci/ado_provider.py
+++ b/agentic_devtools/cli/ci/ado_provider.py
@@ -144,6 +144,10 @@ class AzureDevOpsProvider(CIPlatformProvider):
         """Not implemented for ADO stub."""
         raise NotImplementedError("AzureDevOpsProvider.merge_pr() not yet implemented")
 
+    def delete_branch(self, branch: str) -> None:
+        """Not implemented for ADO stub."""
+        raise NotImplementedError("AzureDevOpsProvider.delete_branch() not yet implemented")
+
     def publish_pr(self, pr_number: int) -> None:
         """Not implemented for ADO stub."""
         raise NotImplementedError("AzureDevOpsProvider.publish_pr() not yet implemented")

--- a/agentic_devtools/cli/ci/github_provider.py
+++ b/agentic_devtools/cli/ci/github_provider.py
@@ -1028,6 +1028,17 @@ class GitHubActionsProvider(CIPlatformProvider):
         )
 
     @retry_with_backoff()
+    def delete_branch(self, branch: str) -> None:
+        """Delete a remote branch via the GitHub API.
+
+        Uses ``DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}``.
+        """
+        _gh_api(
+            self._repo_api(f"/git/refs/heads/{branch}"),
+            method="DELETE",
+        )
+
+    @retry_with_backoff()
     def publish_pr(self, pr_number: int) -> None:
         """Mark a draft PR as ready for review via gh pr ready command."""
         cmd = ["gh", "pr", "ready", str(pr_number)]

--- a/agentic_devtools/cli/ci/pipeline/actions/merge.py
+++ b/agentic_devtools/cli/ci/pipeline/actions/merge.py
@@ -212,6 +212,20 @@ class MergeAction:
                 details="merge_pr call failed",
             )
 
+        # Delete the source branch after successful merge
+        if snapshot.head_branch:
+            try:
+                provider.delete_branch(snapshot.head_branch)
+                logger.info("PR #%d: Deleted branch %s", snapshot.pr_number, snapshot.head_branch)
+            except Exception as exc:
+                # Branch deletion is best-effort; don't fail the merge action
+                logger.warning(
+                    "PR #%d: Failed to delete branch %s: %s",
+                    snapshot.pr_number,
+                    snapshot.head_branch,
+                    exc,
+                )
+
         logger.info("PR #%d: Merged successfully (method=%s)", snapshot.pr_number, method)
         return ActionResult(
             name=self.name,

--- a/agentic_devtools/cli/ci/provider.py
+++ b/agentic_devtools/cli/ci/provider.py
@@ -139,6 +139,17 @@ class CIPlatformProvider(ABC):
         """
 
     @abstractmethod
+    def delete_branch(self, branch: str) -> None:
+        """Delete a remote branch.
+
+        Args:
+            branch: Branch name to delete (e.g., "feature/my-branch").
+
+        Raises:
+            RuntimeError: If the branch could not be deleted.
+        """
+
+    @abstractmethod
     def publish_pr(self, pr_number: int) -> None:
         """Mark a draft pull request as ready for review.
 

--- a/tests/unit/cli/ci/ado_provider/test_azuredevopsprovider.py
+++ b/tests/unit/cli/ci/ado_provider/test_azuredevopsprovider.py
@@ -82,6 +82,8 @@ class TestAzureDevOpsProvider:
         with pytest.raises(NotImplementedError):
             provider.merge_pr(1, "sha", "squash", commit_title="Title (#1)")
         with pytest.raises(NotImplementedError):
+            provider.delete_branch("feature/test")
+        with pytest.raises(NotImplementedError):
             provider.request_reviewer(1, "user")
         with pytest.raises(NotImplementedError):
             provider.count_unresolved_review_threads(1)

--- a/tests/unit/cli/ci/github_provider/test_delete_branch.py
+++ b/tests/unit/cli/ci/github_provider/test_delete_branch.py
@@ -1,0 +1,40 @@
+"""Tests for GitHubActionsProvider.delete_branch() method."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agentic_devtools.cli.ci.github_provider import GitHubActionsProvider
+
+
+class TestDeleteBranch:
+    """Tests for GitHubActionsProvider.delete_branch()."""
+
+    @patch("agentic_devtools.cli.ci.github_provider.run_safe")
+    def test_delete_branch_calls_correct_endpoint(self, mock_run_safe) -> None:
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        mock_run_safe.return_value = _Result()
+
+        provider = GitHubActionsProvider(repo="owner/repo")
+        provider.delete_branch("feature/my-branch")
+
+        args = mock_run_safe.call_args[0][0]
+        assert "/repos/owner/repo/git/refs/heads/feature/my-branch" in " ".join(args)
+        assert "DELETE" in args
+
+    @patch("agentic_devtools.cli.ci.github_provider.run_safe")
+    def test_delete_branch_raises_on_failure(self, mock_run_safe) -> None:
+        class _Result:
+            returncode = 1
+            stdout = ""
+            stderr = "Reference does not exist"
+
+        mock_run_safe.return_value = _Result()
+
+        provider = GitHubActionsProvider(repo="owner/repo")
+        with pytest.raises(RuntimeError):
+            provider.delete_branch("nonexistent-branch")

--- a/tests/unit/cli/ci/pipeline/actions/merge/test_mergeaction.py
+++ b/tests/unit/cli/ci/pipeline/actions/merge/test_mergeaction.py
@@ -286,3 +286,40 @@ class TestMergeAction:
 
         assert result.decision == ActionDecision.FAILED
         assert "merge_pr call failed" in result.details
+
+    def test_execute_deletes_branch_after_merge(self) -> None:
+        """MergeAction deletes the source branch after successful merge."""
+        snapshot = PRStateSnapshot(pr_number=42, head_sha="sha123", commit_count=1, head_branch="feature/my-branch")
+        derived = DerivedState(snapshot)
+        provider = MagicMock()
+        action = MergeAction()
+
+        result = action.execute(provider, snapshot, derived)
+
+        assert result.decision == ActionDecision.EXECUTE
+        provider.delete_branch.assert_called_once_with("feature/my-branch")
+
+    def test_execute_skips_branch_deletion_when_head_branch_empty(self) -> None:
+        """MergeAction skips branch deletion when head_branch is empty."""
+        snapshot = PRStateSnapshot(pr_number=42, head_sha="sha123", commit_count=1, head_branch="")
+        derived = DerivedState(snapshot)
+        provider = MagicMock()
+        action = MergeAction()
+
+        result = action.execute(provider, snapshot, derived)
+
+        assert result.decision == ActionDecision.EXECUTE
+        provider.delete_branch.assert_not_called()
+
+    def test_execute_succeeds_when_branch_deletion_fails(self) -> None:
+        """MergeAction still succeeds if branch deletion raises."""
+        snapshot = PRStateSnapshot(pr_number=42, head_sha="sha123", commit_count=1, head_branch="feature/branch")
+        derived = DerivedState(snapshot)
+        provider = MagicMock()
+        provider.delete_branch.side_effect = RuntimeError("branch already deleted")
+        action = MergeAction()
+
+        result = action.execute(provider, snapshot, derived)
+
+        assert result.decision == ActionDecision.EXECUTE
+        assert "merged" in result.details.lower()

--- a/tests/unit/cli/ci/provider/test_ciplatformprovider.py
+++ b/tests/unit/cli/ci/provider/test_ciplatformprovider.py
@@ -45,6 +45,9 @@ class _ConcreteProvider(CIPlatformProvider):
     def merge_pr(self, pr_number: int, head_sha: str, method: str, *, commit_title: str | None = None) -> None:
         pass
 
+    def delete_branch(self, branch: str) -> None:
+        pass
+
     def request_reviewer(self, pr_number: int, reviewer: str) -> None:
         pass
 
@@ -239,6 +242,7 @@ class TestCIPlatformProvider:
             "find_comment",
             "approve_pr",
             "merge_pr",
+            "delete_branch",
             "publish_pr",
             "squash_before_publish",
             "request_reviewer",

--- a/tests/unit/cli/ci/provider/test_ciplatformprovider_integration.py
+++ b/tests/unit/cli/ci/provider/test_ciplatformprovider_integration.py
@@ -57,6 +57,9 @@ class _StubAdoProvider(CIPlatformProvider):
     def merge_pr(self, pr_number: int, head_sha: str, method: str, *, commit_title: str | None = None) -> None:
         raise NotImplementedError("ADO provider stub")
 
+    def delete_branch(self, branch: str) -> None:
+        raise NotImplementedError("ADO provider stub")
+
     def request_reviewer(self, pr_number: int, reviewer: str) -> None:
         raise NotImplementedError("ADO provider stub")
 


### PR DESCRIPTION
## Summary

When the ai-pr-loop merges a PR, automatically delete the source branch on origin. This prevents stale branches from accumulating (previously 135+ stale branches had to be cleaned up manually).

## Changes

- **provider.py**: Added abstract `delete_branch(branch)` method to `CIPlatformProvider`
- **github_provider.py**: Implemented `delete_branch` via GitHub REST API (`DELETE /git/refs/heads/{branch}`) with retry
- **ado_provider.py**: Added `NotImplementedError` stub for interface compliance
- **pipeline/actions/merge.py**: Call `delete_branch` after successful merge in `MergeAction.execute()`
  - Branch deletion is **best-effort**: logged as a warning on failure, does not affect the merge result

## Behavior

- After a PR is merged by the ai-pr-loop, the head branch is immediately deleted
- If branch deletion fails (e.g., already deleted, permission issue), a warning is logged but the merge action still reports success
- This matches the behavior of `agdt-gh-pr-merge` which already passes `--delete-branch` by default