### PR TITLE
fix: wire create-jira-issue/epic/subtask no-issue-key path to perform_auto_setup

### DIFF
--- a/agentic_devtools/cli/workflows/commands.py
+++ b/agentic_devtools/cli/workflows/commands.py
@@ -1399,7 +1399,7 @@ def initiate_create_jira_issue_workflow(
 
     from ...state import get_value, set_value
     from .preflight import check_worktree_and_branch, perform_auto_setup
-    from .worktree_setup import create_placeholder_and_setup_worktree
+    from .worktree_setup import create_placeholder_issue, generate_workflow_branch_name
 
     # Parse CLI arguments first — no state I/O at this point.
     parser = argparse.ArgumentParser(description="Initiate the create-jira-issue workflow")
@@ -1585,16 +1585,63 @@ def initiate_create_jira_issue_workflow(
             else:
                 sys.exit(1)
 
-    # No issue key - create placeholder and set up worktree
-    success, created_issue_key = create_placeholder_and_setup_worktree(
+    # No issue key - create placeholder, then auto-setup with update workflow
+    print(f"\n{'=' * 80}")
+    print("CREATE WORKFLOW: create-jira-issue")
+    print("=" * 80)
+    print("\n\U0001f4dd Step 1: Creating placeholder Jira issue...")
+
+    issue_result = create_placeholder_issue(
         project_key=resolved_project_key,
         issue_type=resolved_issue_type,
-        workflow_name="create-jira-issue",
-        user_request=resolved_user_request,
     )
 
-    if success:
-        print(_format_auto_setup_success_message("create-jira-issue", created_issue_key or "placeholder"))
+    if not issue_result.success or not issue_result.issue_key:
+        print(f"\n\u274c Failed to create placeholder issue: {issue_result.error_message}")
+        sys.exit(1)
+
+    created_issue_key = issue_result.issue_key
+    set_value("jira.issue_key", created_issue_key)
+
+    # Build user request for the update workflow
+    update_user_request = (
+        "This is a placeholder issue that needs to be populated with a proper "
+        "description, acceptance criteria, and additional information."
+    )
+    if resolved_user_request:
+        update_user_request += f" Here is what the issue should cover: {resolved_user_request}"
+
+    # Build auto-execute command for the new worktree
+    auto_execute_command = [
+        "agdt-initiate-update-jira-issue-workflow",
+        "--issue-key",
+        created_issue_key,
+        "--interactive",
+        "true" if interactive else "false",
+        "--model",
+        model,
+        "--skip-copilot-session",
+        "--user-request",
+        update_user_request,
+    ]
+
+    # Use the issue-type-based branch naming
+    branch_name = generate_workflow_branch_name(
+        issue_key=created_issue_key,
+        issue_type=resolved_issue_type,
+        workflow_name="create-jira-issue",
+    )
+
+    if perform_auto_setup(
+        created_issue_key,
+        "update-jira-issue",
+        branch_name=branch_name,
+        user_request=update_user_request,
+        auto_execute_command=auto_execute_command,
+        interactive=interactive,
+        model=model,
+    ):
+        print(_format_auto_setup_success_message("update-jira-issue", created_issue_key))
     else:
         sys.exit(1)
 
@@ -1647,7 +1694,7 @@ def initiate_create_jira_epic_workflow(
 
     from ...state import get_value, set_value
     from .preflight import check_worktree_and_branch, perform_auto_setup
-    from .worktree_setup import create_placeholder_and_setup_worktree
+    from .worktree_setup import create_placeholder_issue, generate_workflow_branch_name
 
     # Parse CLI arguments first — no state I/O at this point.
     parser = argparse.ArgumentParser(description="Initiate the create-jira-epic workflow")
@@ -1817,16 +1864,63 @@ def initiate_create_jira_epic_workflow(
             else:
                 sys.exit(1)
 
-    # No issue key - create placeholder and set up worktree
-    success, created_issue_key = create_placeholder_and_setup_worktree(
+    # No issue key - create placeholder, then auto-setup with update workflow
+    print(f"\n{'=' * 80}")
+    print("CREATE WORKFLOW: create-jira-epic")
+    print("=" * 80)
+    print("\n\U0001f4dd Step 1: Creating placeholder Epic...")
+
+    issue_result = create_placeholder_issue(
         project_key=resolved_project_key,
         issue_type="Epic",
-        workflow_name="create-jira-epic",
-        user_request=resolved_user_request,
     )
 
-    if success:
-        print(_format_auto_setup_success_message("create-jira-epic", created_issue_key or "placeholder"))
+    if not issue_result.success or not issue_result.issue_key:
+        print(f"\n\u274c Failed to create placeholder issue: {issue_result.error_message}")
+        sys.exit(1)
+
+    created_issue_key = issue_result.issue_key
+    set_value("jira.issue_key", created_issue_key)
+
+    # Build user request for the update workflow
+    update_user_request = (
+        "This is a placeholder issue that needs to be populated with a proper "
+        "description, acceptance criteria, and additional information."
+    )
+    if resolved_user_request:
+        update_user_request += f" Here is what the issue should cover: {resolved_user_request}"
+
+    # Build auto-execute command for the new worktree
+    auto_execute_command = [
+        "agdt-initiate-update-jira-issue-workflow",
+        "--issue-key",
+        created_issue_key,
+        "--interactive",
+        "true" if interactive else "false",
+        "--model",
+        model,
+        "--skip-copilot-session",
+        "--user-request",
+        update_user_request,
+    ]
+
+    # Use the issue-type-based branch naming
+    branch_name = generate_workflow_branch_name(
+        issue_key=created_issue_key,
+        issue_type="Epic",
+        workflow_name="create-jira-epic",
+    )
+
+    if perform_auto_setup(
+        created_issue_key,
+        "update-jira-issue",
+        branch_name=branch_name,
+        user_request=update_user_request,
+        auto_execute_command=auto_execute_command,
+        interactive=interactive,
+        model=model,
+    ):
+        print(_format_auto_setup_success_message("update-jira-issue", created_issue_key))
     else:
         sys.exit(1)
 
@@ -1876,7 +1970,7 @@ def initiate_create_jira_subtask_workflow(
 
     from ...state import get_value, set_value
     from .preflight import check_worktree_and_branch, perform_auto_setup
-    from .worktree_setup import create_placeholder_and_setup_worktree
+    from .worktree_setup import create_placeholder_issue, generate_workflow_branch_name
 
     # Parse CLI arguments first — no state I/O at this point.
     parser = argparse.ArgumentParser(description="Initiate the create-jira-subtask workflow")
@@ -2059,18 +2153,65 @@ def initiate_create_jira_subtask_workflow(
     # Extract project key from parent key
     project_key = resolved_parent_key.split("-")[0] if resolved_parent_key else "PROJECT"
 
-    # Create placeholder and set up worktree
-    success, created_issue_key = create_placeholder_and_setup_worktree(
+    # Create placeholder, then auto-setup with update workflow
+    print(f"\n{'=' * 80}")
+    print("CREATE WORKFLOW: create-jira-subtask")
+    print("=" * 80)
+    print("\n\U0001f4dd Step 1: Creating placeholder Sub-task...")
+
+    issue_result = create_placeholder_issue(
         project_key=project_key,
         issue_type="Sub-task",
         parent_key=resolved_parent_key,
-        workflow_name="create-jira-subtask",
-        user_request=resolved_user_request,
-        additional_params={"parent_key": resolved_parent_key},
     )
 
-    if success:
-        print(_format_auto_setup_success_message("create-jira-subtask", created_issue_key or "placeholder"))
+    if not issue_result.success or not issue_result.issue_key:
+        print(f"\n\u274c Failed to create placeholder issue: {issue_result.error_message}")
+        sys.exit(1)
+
+    created_issue_key = issue_result.issue_key
+    set_value("jira.issue_key", created_issue_key)
+
+    # Build user request for the update workflow
+    update_user_request = (
+        "This is a placeholder issue that needs to be populated with a proper "
+        "description, acceptance criteria, and additional information."
+    )
+    if resolved_user_request:
+        update_user_request += f" Here is what the issue should cover: {resolved_user_request}"
+
+    # Build auto-execute command for the new worktree
+    auto_execute_command = [
+        "agdt-initiate-update-jira-issue-workflow",
+        "--issue-key",
+        created_issue_key,
+        "--interactive",
+        "true" if interactive else "false",
+        "--model",
+        model,
+        "--skip-copilot-session",
+        "--user-request",
+        update_user_request,
+    ]
+
+    # Use the issue-type-based branch naming
+    branch_name = generate_workflow_branch_name(
+        issue_key=created_issue_key,
+        issue_type="Sub-task",
+        workflow_name="create-jira-subtask",
+        parent_key=resolved_parent_key,
+    )
+
+    if perform_auto_setup(
+        created_issue_key,
+        "update-jira-issue",
+        branch_name=branch_name,
+        user_request=update_user_request,
+        auto_execute_command=auto_execute_command,
+        interactive=interactive,
+        model=model,
+    ):
+        print(_format_auto_setup_success_message("update-jira-issue", created_issue_key))
     else:
         sys.exit(1)
 

--- a/tests/unit/cli/workflows/commands/test_initiate_create_jira_epic_workflow.py
+++ b/tests/unit/cli/workflows/commands/test_initiate_create_jira_epic_workflow.py
@@ -171,32 +171,89 @@ class TestInitiateCreateJiraEpicWorkflowBranches:
                 assert exc_info.value.code == 1
 
     def test_no_issue_key_creates_placeholder(self, temp_state_dir, clear_state_before, capsys):
-        """Test when no issue_key provided, calls create_placeholder_and_setup_worktree."""
+        """Test when no issue_key provided, creates placeholder and calls perform_auto_setup."""
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-9999")
-            commands.initiate_create_jira_epic_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=[])
 
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args[1]
         assert call_kwargs["issue_type"] == "Epic"
+        mock_setup.assert_called_once()
+        setup_kwargs = mock_setup.call_args[1]
+        setup_args = mock_setup.call_args[0]
+        assert setup_args[1] == "update-jira-issue"
+        assert setup_kwargs["auto_execute_command"][0] == "agdt-initiate-update-jira-issue-workflow"
+        assert "PROJECT-9999" in setup_kwargs["auto_execute_command"]
         captured = capsys.readouterr()
         assert "Copilot session will start automatically" in captured.out
+
+    def test_no_issue_key_no_user_request_does_not_inject_none(self, temp_state_dir, clear_state_before, capsys):
+        """When no user_request is provided, 'None' must not appear in the update_user_request."""
+        state.set_value("jira.project_key", "PROJECT")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=[])
+
+        call_kwargs = mock_setup.call_args[1]
+        assert "None" not in call_kwargs["user_request"]
+        assert "None" not in " ".join(call_kwargs["auto_execute_command"])
+
+    def test_no_issue_key_user_request_propagated_consistently(self, temp_state_dir, clear_state_before, capsys):
+        """The user_request kwarg to perform_auto_setup must match what's in auto_execute_command."""
+        state.set_value("jira.project_key", "PROJECT")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=["--user-request", "Build an auth epic"])
+
+        call_kwargs = mock_setup.call_args[1]
+        auto_cmd = call_kwargs["auto_execute_command"]
+        user_request_kwarg = call_kwargs["user_request"]
+        ur_idx = auto_cmd.index("--user-request") + 1
+        assert auto_cmd[ur_idx] == user_request_kwarg
+        assert "Build an auth epic" in user_request_kwarg
 
     def test_no_issue_key_placeholder_creation_fails(self, temp_state_dir, clear_state_before, capsys):
         """Test when placeholder creation fails."""
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (False, None)
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=False, error_message="API error")
             with pytest.raises(SystemExit) as exc_info:
                 commands.initiate_create_jira_epic_workflow(_argv=[])
             assert exc_info.value.code == 1
+
+    def test_no_issue_key_auto_setup_fails(self, temp_state_dir, clear_state_before, capsys):
+        """Test when placeholder succeeds but perform_auto_setup fails."""
+        state.set_value("jira.project_key", "PROJECT")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = False
+                with pytest.raises(SystemExit) as exc_info:
+                    commands.initiate_create_jira_epic_workflow(_argv=[])
+                assert exc_info.value.code == 1
 
 
 class TestInitiateCreateJiraEpicInteractive:
@@ -386,19 +443,19 @@ class TestCreateJiraEpicStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
 
             def _mock_create_placeholder(**_kwargs):
                 # Stale key must be cleared before placeholder creation starts.
                 assert state.get_value("jira.issue_key") is None
-                # Simulate real helper behavior by persisting the new placeholder key.
-                state.set_value("jira.issue_key", "PROJECT-NEW-1")
-                return (True, "PROJECT-NEW-1")
+                return PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
 
             mock_create.side_effect = _mock_create_placeholder
-            commands.initiate_create_jira_epic_workflow(_argv=[])
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=[])
 
         # Stale key was cleared — create path was taken (not the existing-issue path)
         mock_create.assert_called_once()
@@ -409,11 +466,13 @@ class TestCreateJiraEpicStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_epic_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=[])
 
         captured = capsys.readouterr()
         assert "Cleared stale issue selection state" in captured.err
@@ -422,11 +481,13 @@ class TestCreateJiraEpicStaleStateClearance:
         """No stderr message when no stale keys exist."""
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_epic_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=[])
 
         captured = capsys.readouterr()
         assert "Cleared stale issue selection state" not in captured.err
@@ -462,10 +523,12 @@ class TestCreateJiraEpicStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.project_key", "MYPROJ")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "MYPROJ-NEW-1")
-            commands.initiate_create_jira_epic_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="MYPROJ-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_epic_workflow(_argv=[])
 
         assert state.get_value("jira.project_key") == "MYPROJ"

--- a/tests/unit/cli/workflows/commands/test_initiate_create_jira_issue_workflow.py
+++ b/tests/unit/cli/workflows/commands/test_initiate_create_jira_issue_workflow.py
@@ -199,30 +199,91 @@ class TestInitiateCreateJiraIssueWorkflowBranches:
                 assert exc_info.value.code == 1
 
     def test_no_issue_key_creates_placeholder(self, temp_state_dir, clear_state_before, capsys):
-        """Test when no issue_key provided, calls create_placeholder_and_setup_worktree."""
+        """Test when no issue_key provided, creates placeholder and calls perform_auto_setup."""
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-9999")
-            commands.initiate_create_jira_issue_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=[])
 
         mock_create.assert_called_once()
+        mock_setup.assert_called_once()
+        # Verify auto_execute_command uses update workflow
+        call_kwargs = mock_setup.call_args[1]
+        call_args = mock_setup.call_args[0]
+        assert call_args[1] == "update-jira-issue"
+        assert call_kwargs["auto_execute_command"][0] == "agdt-initiate-update-jira-issue-workflow"
+        assert "--issue-key" in call_kwargs["auto_execute_command"]
+        assert "PROJECT-9999" in call_kwargs["auto_execute_command"]
         captured = capsys.readouterr()
         assert "Copilot session will start automatically" in captured.out
+
+    def test_no_issue_key_no_user_request_does_not_inject_none(self, temp_state_dir, clear_state_before, capsys):
+        """When no user_request is provided, 'None' must not appear in the update_user_request."""
+        state.set_value("jira.project_key", "PROJECT")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=[])
+
+        call_kwargs = mock_setup.call_args[1]
+        assert "None" not in call_kwargs["user_request"]
+        assert "None" not in " ".join(call_kwargs["auto_execute_command"])
+
+    def test_no_issue_key_user_request_propagated_consistently(self, temp_state_dir, clear_state_before, capsys):
+        """The user_request kwarg to perform_auto_setup must match what's in auto_execute_command."""
+        state.set_value("jira.project_key", "PROJECT")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=["--user-request", "Build a login feature"])
+
+        call_kwargs = mock_setup.call_args[1]
+        auto_cmd = call_kwargs["auto_execute_command"]
+        user_request_kwarg = call_kwargs["user_request"]
+        # The --user-request arg in auto_execute_command must equal the user_request kwarg
+        ur_idx = auto_cmd.index("--user-request") + 1
+        assert auto_cmd[ur_idx] == user_request_kwarg
+        # Both must include the original user request text
+        assert "Build a login feature" in user_request_kwarg
 
     def test_no_issue_key_placeholder_creation_fails(self, temp_state_dir, clear_state_before, capsys):
         """Test when placeholder creation fails."""
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (False, None)
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=False, error_message="API error")
             with pytest.raises(SystemExit) as exc_info:
                 commands.initiate_create_jira_issue_workflow(_argv=[])
             assert exc_info.value.code == 1
+
+    def test_no_issue_key_auto_setup_fails(self, temp_state_dir, clear_state_before, capsys):
+        """Test when placeholder succeeds but perform_auto_setup fails."""
+        state.set_value("jira.project_key", "PROJECT")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-9999")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = False
+                with pytest.raises(SystemExit) as exc_info:
+                    commands.initiate_create_jira_issue_workflow(_argv=[])
+                assert exc_info.value.code == 1
 
 
 class TestInitiateCreateJiraIssueInteractive:
@@ -415,19 +476,19 @@ class TestCreateJiraIssueStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
 
             def _mock_create_placeholder(**_kwargs):
                 # Stale key must be cleared before placeholder creation starts.
                 assert state.get_value("jira.issue_key") is None
-                # Simulate real helper behavior by persisting the new placeholder key.
-                state.set_value("jira.issue_key", "PROJECT-NEW-1")
-                return (True, "PROJECT-NEW-1")
+                return PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
 
             mock_create.side_effect = _mock_create_placeholder
-            commands.initiate_create_jira_issue_workflow(_argv=[])
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=[])
 
         # Stale key was cleared — create path was taken (not the existing-issue path)
         mock_create.assert_called_once()
@@ -438,11 +499,13 @@ class TestCreateJiraIssueStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_issue_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=[])
 
         captured = capsys.readouterr()
         assert "Cleared stale issue selection state" in captured.err
@@ -451,11 +514,13 @@ class TestCreateJiraIssueStaleStateClearance:
         """No stderr message when no stale keys exist."""
         state.set_value("jira.project_key", "PROJECT")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_issue_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=[])
 
         captured = capsys.readouterr()
         assert "Cleared stale issue selection state" not in captured.err
@@ -491,10 +556,12 @@ class TestCreateJiraIssueStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.project_key", "MYPROJ")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "MYPROJ-NEW-1")
-            commands.initiate_create_jira_issue_workflow(_argv=[])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="MYPROJ-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_issue_workflow(_argv=[])
 
         assert state.get_value("jira.project_key") == "MYPROJ"

--- a/tests/unit/cli/workflows/commands/test_initiate_create_jira_subtask_workflow.py
+++ b/tests/unit/cli/workflows/commands/test_initiate_create_jira_subtask_workflow.py
@@ -170,33 +170,110 @@ class TestInitiateCreateJiraSubtaskWorkflowBranches:
         assert "--parent-key is required" in captured.out
 
     def test_no_issue_key_creates_placeholder(self, temp_state_dir, clear_state_before, capsys):
-        """Test when no issue_key but parent_key provided, creates placeholder."""
+        """Test when no issue_key but parent_key provided, creates placeholder and auto-setup."""
         state.set_value("jira.parent_key", "PROJECT-1234")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-1235")
-            commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-1235")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
 
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args[1]
         assert call_kwargs["issue_type"] == "Sub-task"
         assert call_kwargs["parent_key"] == "PROJECT-1234"
+        mock_setup.assert_called_once()
+        setup_kwargs = mock_setup.call_args[1]
+        setup_args = mock_setup.call_args[0]
+        assert setup_args[1] == "update-jira-issue"
+        assert setup_kwargs["auto_execute_command"][0] == "agdt-initiate-update-jira-issue-workflow"
+        assert "PROJECT-1235" in setup_kwargs["auto_execute_command"]
         captured = capsys.readouterr()
         assert "Copilot session will start automatically" in captured.out
+
+    def test_no_issue_key_no_additional_params_for_update_workflow(self, temp_state_dir, clear_state_before, capsys):
+        """The update-jira-issue workflow does not accept --parent-key, so additional_params
+        must be None (or absent) when perform_auto_setup targets update-jira-issue."""
+        state.set_value("jira.parent_key", "PROJECT-1234")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-1235")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+
+        setup_kwargs = mock_setup.call_args[1]
+        # additional_params must not contain parent_key — update-jira-issue doesn't accept --parent-key
+        additional_params = setup_kwargs.get("additional_params")
+        assert additional_params is None or "parent_key" not in additional_params
+
+    def test_no_issue_key_no_user_request_does_not_inject_none(self, temp_state_dir, clear_state_before, capsys):
+        """When no user_request is provided, 'None' must not appear in the update_user_request."""
+        state.set_value("jira.parent_key", "PROJECT-1234")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-1235")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+
+        call_kwargs = mock_setup.call_args[1]
+        assert "None" not in call_kwargs["user_request"]
+        assert "None" not in " ".join(call_kwargs["auto_execute_command"])
+
+    def test_no_issue_key_user_request_propagated_consistently(self, temp_state_dir, clear_state_before, capsys):
+        """The user_request kwarg to perform_auto_setup must match what's in auto_execute_command."""
+        state.set_value("jira.parent_key", "PROJECT-1234")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-1235")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(
+                    _argv=["--parent-key", "PROJECT-1234", "--user-request", "Add unit tests"]
+                )
+
+        call_kwargs = mock_setup.call_args[1]
+        auto_cmd = call_kwargs["auto_execute_command"]
+        user_request_kwarg = call_kwargs["user_request"]
+        ur_idx = auto_cmd.index("--user-request") + 1
+        assert auto_cmd[ur_idx] == user_request_kwarg
+        assert "Add unit tests" in user_request_kwarg
 
     def test_no_issue_key_placeholder_creation_fails(self, temp_state_dir, clear_state_before, capsys):
         """Test when placeholder creation fails."""
         state.set_value("jira.parent_key", "PROJECT-1234")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (False, None)
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=False, error_message="API error")
             with pytest.raises(SystemExit) as exc_info:
                 commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
             assert exc_info.value.code == 1
+
+    def test_no_issue_key_auto_setup_fails(self, temp_state_dir, clear_state_before, capsys):
+        """Test when placeholder succeeds but perform_auto_setup fails."""
+        state.set_value("jira.parent_key", "PROJECT-1234")
+
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-1235")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = False
+                with pytest.raises(SystemExit) as exc_info:
+                    commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+                assert exc_info.value.code == 1
 
 
 class TestProgrammaticParamsSkipCliOverride:
@@ -467,19 +544,19 @@ class TestCreateJiraSubtaskStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.parent_key", "PROJECT-1234")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
 
             def _mock_create_placeholder(**_kwargs):
                 # Stale key must be cleared before placeholder creation starts.
                 assert state.get_value("jira.issue_key") is None
-                # Simulate real helper behavior by persisting the new placeholder key.
-                state.set_value("jira.issue_key", "PROJECT-NEW-1")
-                return (True, "PROJECT-NEW-1")
+                return PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
 
             mock_create.side_effect = _mock_create_placeholder
-            commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
 
         # Stale key was cleared — create path was taken (not the existing-issue path)
         mock_create.assert_called_once()
@@ -490,11 +567,13 @@ class TestCreateJiraSubtaskStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.parent_key", "PROJECT-1234")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
 
         captured = capsys.readouterr()
         assert "Cleared stale issue selection state" in captured.err
@@ -503,11 +582,13 @@ class TestCreateJiraSubtaskStaleStateClearance:
         """No stderr message when no stale keys exist."""
         state.set_value("jira.parent_key", "PROJECT-1234")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
 
         captured = capsys.readouterr()
         assert "Cleared stale issue selection state" not in captured.err
@@ -545,10 +626,12 @@ class TestCreateJiraSubtaskStaleStateClearance:
         state.set_value("jira.issue_key", "STALE-999")
         state.set_value("jira.parent_key", "PROJECT-1234")
 
-        with patch(
-            "agentic_devtools.cli.workflows.worktree_setup.create_placeholder_and_setup_worktree"
-        ) as mock_create:
-            mock_create.return_value = (True, "PROJECT-NEW-1")
-            commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
+        from agentic_devtools.cli.workflows.worktree_setup import PlaceholderIssueResult
+
+        with patch("agentic_devtools.cli.workflows.worktree_setup.create_placeholder_issue") as mock_create:
+            mock_create.return_value = PlaceholderIssueResult(success=True, issue_key="PROJECT-NEW-1")
+            with patch("agentic_devtools.cli.workflows.preflight.perform_auto_setup") as mock_setup:
+                mock_setup.return_value = True
+                commands.initiate_create_jira_subtask_workflow(_argv=["--parent-key", "PROJECT-1234"])
 
         assert state.get_value("jira.parent_key") == "PROJECT-1234"

--- a/tests/unit/cli/workflows/commands/test_initiate_pull_request_review_workflow.py
+++ b/tests/unit/cli/workflows/commands/test_initiate_pull_request_review_workflow.py
@@ -1,7 +1,9 @@
 """Tests for TestInitiatePRReviewWorkflowBranches."""
 
+import errno
 import json
 import logging
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -1292,7 +1294,14 @@ class TestSkipCopilotSession:
 
         # Place a dangling symlink where the prompt file would normally be
         stale_link = temp_state_dir / "temp-pull-request-review-initiate-prompt.md"
-        stale_link.symlink_to(temp_state_dir / "nonexistent-target.md")
+        try:
+            stale_link.symlink_to(temp_state_dir / "nonexistent-target.md")
+        except OSError as exc:
+            if sys.platform.startswith("win") and (
+                getattr(exc, "winerror", None) == 1314 or exc.errno in {errno.EPERM, errno.EACCES}
+            ):
+                pytest.skip("Symlink creation requires elevated privileges on Windows")
+            raise
         assert stale_link.is_symlink()
         assert not stale_link.exists()  # Dangling — target does not exist
 


### PR DESCRIPTION
## Problem

When running \agdt-initiate-create-jira-issue-workflow --project-key X --issue-type Bug --user-request '...'\ without \--issue-key\, the command:
1. Created a placeholder Jira issue
2. Created a worktree and opened VS Code
3. **But never started a workflow or Copilot session in the new worktree**

The same bug affected \initiate_create_jira_epic_workflow\ and \initiate_create_jira_subtask_workflow\.

## Root Cause

The no-issue-key path called \create_placeholder_and_setup_worktree()\ which uses the simple \setup_worktree_environment()\ helper — this has no concept of auto-execute commands, Copilot sessions, or VS Code folder-open task injection.

## Fix

Replaced the no-issue-key path in all 3 create workflows to:
1. Call \create_placeholder_issue()\ directly (issue creation only)
2. Build an \auto_execute_command\ targeting \agdt-initiate-update-jira-issue-workflow --issue-key {KEY} --user-request '...'\
3. Call \perform_auto_setup()\ which triggers the full background setup pipeline (worktree + auto-execute + Copilot session)

## Additional Fix

Fixed a pre-existing Windows symlink test failure (\test_dangling_symlink_at_stale_prompt_path_exits_with_error\) that was causing the pre-push hook to report failure despite 100% coverage. The test now gracefully skips when symlink creation fails due to missing Windows privileges.

## Testing

- All 422 tests pass (1 skipped on Windows)
- 100% coverage on \commands.py\ (1307 stmts, 552 branches)
- Verified end-to-end: ran the command from \dfly-platform-management\, confirmed worktree created, update workflow initiated with correct issue key, Copilot auto-start triggered