### PR TITLE
feat: add fix-workflow and test-workflow agents with shared development lifecycle

### DIFF
--- a/.github/agents/agdt.fix-workflow.agent.md
+++ b/.github/agents/agdt.fix-workflow.agent.md
@@ -1,0 +1,32 @@
+---
+description: "Fix Workflow: Diagnose and fix a bug in an agentic-devtools workflow command"
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+Expected input: a description of the failing command, observed behavior, expected behavior,
+source repo path (where to run the command), test repo path (where to run repro during testing),
+and test command (the integration-test command).
+
+## Purpose
+
+Investigate a reported bug in an `agentic-devtools` CLI workflow command, identify root cause,
+implement a fix with tests, and deliver a PR — all while ensuring the pre-push hook passes
+and the fix is verified end-to-end.
+
+## Instructions
+
+Follow the detailed instructions in the corresponding prompt file
+(`.github/prompts/agdt.fix-workflow.prompt.md`).
+
+The shared development lifecycle phases (implementation, push, integration test, delivery)
+are defined in `.github/instructions/workflow-development.instructions.md`.
+
+## Next Step
+
+Task is complete when a PR is created and all artifacts are reported.

--- a/.github/agents/agdt.test-workflow.agent.md
+++ b/.github/agents/agdt.test-workflow.agent.md
@@ -1,0 +1,35 @@
+---
+description: "Test Workflow: Execute an agentic-devtools command, audit its behavior, and fix any findings"
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+Expected input: the CLI command to test, the repo path to run it from, and any relevant context.
+
+## Purpose
+
+Audit the behavior of an `agentic-devtools` CLI command by documenting expectations first,
+executing and observing, identifying bugs/inefficiencies/improvements, then implementing
+fixes and verifying with a clean rerun.
+
+## Instructions
+
+Follow the detailed instructions in the corresponding prompt file
+(`.github/prompts/agdt.test-workflow.prompt.md`).
+
+The shared development lifecycle phases (implementation, push, integration test, delivery)
+are defined in `.github/instructions/workflow-development.instructions.md`.
+
+## Important
+
+**Do NOT execute the command until you have documented expectations and received user confirmation.**
+The expectations document must be reviewed by a rubber duck subagent and presented to the user first.
+
+## Next Step
+
+Task is complete when a PR is created and the final clean rerun matches expectations.

--- a/.github/instructions/workflow-development.instructions.md
+++ b/.github/instructions/workflow-development.instructions.md
@@ -1,0 +1,101 @@
+---
+applyTo: ".github/prompts/agdt.*-workflow.prompt.md"
+---
+
+# Shared: agentic-devtools Workflow Development Lifecycle
+
+This instructions file contains the shared phases used by both the `fix-workflow` and `test-workflow`
+agents. Both agents implement, test, and deliver changes to the agentic-devtools codebase using
+the identical process below.
+
+---
+
+## Implementation Phase
+
+1. Create a new branch in agentic-devtools following the repo convention: `type/ISSUE-KEY/description`
+   (e.g. `fix/1234/fix-save-work-amend` or `feature/1234/add-webhook-support`).
+2. Implement the changes.
+3. Update or create tests to cover all modified code paths. Ensure both success AND failure branches are tested.
+4. Run targeted checks on your changed files:
+   - `ruff check <files> --no-fix` (lint)
+   - `ruff format --check <files>` (format — auto-fix with `ruff format <files>` if needed)
+   - `python -m mypy <source-files> --ignore-missing-imports --follow-imports=silent` (type check)
+   - `agdt-test-pattern <test-files> --no-cov` (unit tests pass — **never** run `pytest` directly;
+     `agdt-test-pattern` runs synchronously and is the right tool for targeted checks; use
+     `agdt-test` / `agdt-test-quick` for full-suite runs, which go through the background-task system)
+
+---
+
+## Push Phase (Pre-Push Hook)
+
+1. Stage, commit, and push using `agdt-git-save-work` (never `git commit` or `git push` directly —
+   this enforces the single-commit-per-PR policy and runs as a background task). Ensure hooks are
+   enabled (`git config core.hooksPath .githooks`) so the push runs the pre-push hook checks.
+2. If the hook fails, read `.pre-push-output.log` in the repo root to see what failed;
+   if available, also review `check-output-condensed.txt` (or `check-output.txt`)
+   for condensed/full failure details. Then fix the issues and rerun `agdt-git-save-work`.
+3. Do NOT use `--no-verify` to bypass the hook. The hook must pass.
+
+### Terminal Rules for Push
+
+- **CRITICAL: Do NOT send any commands to the terminal running `git push` while the pre-push hook is executing.** Sending any input will interrupt the hook and you must retry.
+- To check progress: read `.pre-push-output.log` from the repo root using a file-read tool or a **separate** terminal.
+- If you accidentally interrupt the push, rerun `agdt-git-save-work` to retry (never use raw `git push`/`git push --force-with-lease`).
+
+---
+
+## Integration Test Phase
+
+1. Install the fixed version: `pip install -e <path-to-agentic-devtools-repo>`
+   (e.g. `pip install -e /home/user/repos/agentic-devtools` on Linux/macOS or
+   `pip install -e C:\repos\agentic-devtools` on Windows).
+2. Run the test command from the test repo.
+3. Verify the expected behavior occurs end-to-end.
+4. If it doesn't work, **fully reset to a clean starting point** before retrying:
+    - Delete any worktrees and branches created in the test repo during the failed run.
+    - Remove any leftover state files (e.g., `.agdt/workflows/` state directories in new worktrees).
+    - Clean up any side effects the workflow produced: PR comments, review threads, pipeline runs,
+      Azure DevOps thread scaffolds, etc. — anything that would prevent the command from running
+      as if invoked for the first time.
+    - The goal is to restore the exact starting conditions so the rerun is a true test, not polluted by prior artifacts.
+    - Then: fix the code, amend the commit, re-push (hook must pass again), reinstall, and retest.
+5. Track any side effects that **cannot** be automatically cleaned up (e.g., Jira issues cannot be deleted via API).
+
+---
+
+## Delivery Phase
+
+1. Create a PR on GitHub from your branch to main.
+2. Report:
+    - The PR URL
+    - A brief summary of what was changed and why
+    - **All artifacts needing manual cleanup** — Jira issue keys, leftover worktrees/branches, PR comments that couldn't be deleted, etc.
+
+---
+
+## Quality Assurance: Rubber Duck Feedback
+
+- **Before reporting your final result**, delegate to a "rubber duck" subagent: give it your findings, plan, or implementation and ask it to critically review
+  for logical errors, missed edge cases, or flawed assumptions. Incorporate its feedback before proceeding.
+- **When delegating to subagents**, instruct each subagent to also use a rubber duck agent to critically review its work before reporting back to you.
+  This ensures each layer of work is validated independently.
+- The goal is to catch mistakes early — before they compound across phases — and reduce the number of install-test-fix loops needed.
+
+---
+
+## General Guidelines
+
+- Use subagents generously for investigation, test-writing, and implementation if the scope is large.
+- The single-commit-per-PR policy applies: always amend, never create additional commits on the branch.
+- If a test fails due to a Windows-specific issue (symlinks, path separators), use `pytest.skip()` with a try/except rather than `@pytest.mark.skipif` with fragile platform detection.
+
+---
+
+## Tips
+
+- The pre-push hook runs a variable set of checks via
+  `python -m agentic_devtools.cli.checks` based on changed files (always test structure
+  validation, plus lint/format/mypy for Python changes, plus per-file coverage checks and
+  possible extra test runs).
+- **Never poll the push terminal for status.** Read `.pre-push-output.log` instead.
+- Coverage failures show specific missing line numbers — read those lines to understand what branches need test coverage.

--- a/.github/prompts/agdt.fix-workflow.prompt.md
+++ b/.github/prompts/agdt.fix-workflow.prompt.md
@@ -1,0 +1,48 @@
+# Fix an agentic-devtools Workflow
+
+You are a senior software engineer diagnosing and fixing a bug in the `agentic-devtools` Python package.
+The user has observed incorrect behavior when running a CLI command. Your job is to investigate, fix,
+test, and deliver a PR — following the phased process below.
+
+---
+
+## Context (provided by user)
+
+- **Command that failed:** (the full CLI command that was run)
+- **Source repo path:** (where the command was invoked from)
+- **Observed behavior:** (what actually happened)
+- **Expected behavior:** (what should have happened — be specific about commands/flow)
+- **Test repo path:** (where to run the repro command during testing)
+- **Test command:** (the command to use for integration testing — may differ from original)
+
+---
+
+## Phase 1: Investigate & Plan
+
+1. Investigate the relevant source code in `agentic_devtools/` to trace the full execution path of the failing command.
+2. Check for relevant logs in the source repo's `.agdt/` directory if they exist.
+3. Identify the root cause — pinpoint the exact code path that diverges from expected behavior.
+4. Save your findings to `.agdt-temp/FINDINGS-<slug>.md` (use a short filesystem-safe slug, e.g. `save-work-amend`).
+5. Create a fix plan in `.agdt-temp/PLAN-<slug>.md` with the specific changes needed.
+
+---
+
+## Phase 2: Implement, Test & Deliver
+
+Follow the shared development lifecycle defined in
+`.github/instructions/workflow-development.instructions.md`:
+
+- Implementation Phase (branch, fix, write tests, local checks)
+- Push Phase (commit, push with pre-push hook — must pass)
+- Integration Test Phase (install, run command, verify, clean-and-retry if needed)
+- Delivery Phase (create PR, report artifacts)
+
+The test command for the Integration Test Phase is the command specified by the user in Context above.
+
+---
+
+## Additional Notes
+
+- The Investigation phase is unique to fix-workflow — you must understand root cause before coding.
+- Use the rubber duck feedback pattern (see workflow-development instructions) throughout all phases.
+- When retrying integration tests, ensure full cleanup of all side effects before each attempt.

--- a/.github/prompts/agdt.test-workflow.prompt.md
+++ b/.github/prompts/agdt.test-workflow.prompt.md
@@ -1,0 +1,121 @@
+# Test & Audit an agentic-devtools Workflow
+
+You are a senior software engineer auditing the behavior of an `agentic-devtools` CLI command.
+Your job is to document expectations, execute the command, observe its actual behavior, identify
+bugs/inefficiencies/improvements, then fix and verify — all in a structured, repeatable process.
+
+---
+
+## Context (provided by user)
+
+- **Command to test:** (the CLI command to execute and audit)
+- **Source repo path:** (where to run the command from)
+- **Additional context:** (any relevant background about what the command should do)
+
+---
+
+## Phase 1: Document Expectations
+
+Before executing anything, investigate the source code to understand what the command
+**should** do, then document your expectations.
+
+1. Read the relevant source code in `agentic_devtools/` to trace the full execution path.
+2. Read any related prompt templates, workflow definitions, or configuration.
+3. Create `.agdt-temp/EXPECTATIONS-<command-slug>.md` with:
+   (where `<command-slug>` is the command name sanitized for filesystem use — replace spaces, slashes,
+   and `--flag` prefixes with hyphens, e.g. `agdt-gh-pr-state` → `agdt-gh-pr-state`)
+
+   **Required structure:**
+
+   ```markdown
+   # Expectations: <command-name>
+
+   ## TL;DR
+   <2-5 sentence summary of what the command does and what you expect to observe>
+
+   ## Execution Flow
+   <Step-by-step expected behavior, numbered>
+
+   ## Observable Side Effects
+   <What files, state, worktrees, API calls, Jira issues, etc. should be created/modified>
+
+   ## Success Criteria
+   <How to verify the command worked correctly>
+   ```
+
+4. Have a rubber duck subagent review your expectations document for completeness and accuracy.
+5. **STOP and present the expectations document to the user.** Wait for confirmation before proceeding.
+
+---
+
+## Phase 2: Execute & Observe
+
+Once the user confirms expectations look good:
+
+1. Run the command from the specified source repo path.
+2. Observe the full execution — terminal output, created files, state changes, side effects.
+3. Compare observed behavior against your documented expectations.
+4. Document findings in `.agdt-temp/OBSERVATIONS-<command-slug>.md`:
+
+   **Required structure:**
+
+   ```markdown
+   # Observations: <command-name>
+
+   ## Summary
+   <Brief overview: did it match expectations?>
+
+   ## Detailed Observations
+   <What happened at each step — quote terminal output where relevant>
+
+   ## Findings
+
+   ### Bugs
+   <Behavior that is clearly wrong or broken>
+
+   ### Inefficiencies
+   <Things that work but are unnecessarily slow, verbose, or convoluted>
+
+   ### Improvement Opportunities
+   <Ideas for better UX, clearer output, or more robust handling>
+
+   ## Artifacts Created
+   <List all side effects: worktrees, branches, Jira issues, state files, etc.>
+   ```
+
+---
+
+## Phase 3: Fix
+
+If any bugs, inefficiencies, or improvements were identified:
+
+1. Prioritize: bugs first, then inefficiencies, then improvements.
+2. For each finding, follow the shared development lifecycle defined in
+   `.github/instructions/workflow-development.instructions.md`:
+    - Create a branch
+    - Implement the fix
+    - Write/update tests
+    - Pass local checks
+    - Push with pre-push hook
+    - Install and integration test
+
+---
+
+## Phase 4: Verify (Clean Rerun)
+
+1. **Fully clean up** all artifacts from Phase 2 (worktrees, branches, state files, side effects).
+2. Reinstall agentic-devtools from your fix branch.
+3. Re-run the exact same command from the same starting point.
+4. Compare the new behavior against your expectations document — confirm all findings are addressed and no regressions introduced.
+5. If issues remain: clean up, fix, re-push, reinstall, and rerun again.
+
+---
+
+## Phase 5: Deliver
+
+1. Create a PR on GitHub from your fix branch to main.
+2. Report:
+    - The PR URL
+    - Summary of findings (bugs fixed, improvements made)
+    - **All artifacts needing manual cleanup** — Jira issue keys, worktrees, branches, etc.
+    - Whether the final clean rerun matched expectations fully


### PR DESCRIPTION
Adds two workflow development agents and a shared instructions file for the common development lifecycle.

## New Files

| File | Purpose |
|------|---------|
| \.github/agents/agdt.fix-workflow.agent.md\ | Agent: diagnose and fix a reported workflow bug |
| \.github/agents/agdt.test-workflow.agent.md\ | Agent: execute a command, audit behavior, fix findings |
| \.github/prompts/agdt.fix-workflow.prompt.md\ | Detailed prompt for the fix agent |
| \.github/prompts/agdt.test-workflow.prompt.md\ | Detailed prompt for the test agent |
| \.github/instructions/workflow-development.instructions.md\ | Shared phases: implementation, push, integration test, delivery |

## How They Work

**fix-workflow**: User reports a bug -> investigate root cause -> fix -> verify -> PR

**test-workflow**: Document expectations -> user confirms -> execute command -> observe and compare -> fix findings -> clean rerun to verify -> PR

Both share the same development lifecycle (push rules, cleanup/retry, delivery, rubber duck QA) via the instructions file.

## Supersedes

This PR supersedes #2048 (which had just the fix-workflow prompt without the agent/shared-instructions architecture).