### PR TITLE
refactor(#2054): update squash-commits to use pre-push hook instead of manual tests

### DIFF
--- a/.github/agents/agdt.squash-commits.agent.md
+++ b/.github/agents/agdt.squash-commits.agent.md
@@ -2,6 +2,13 @@
 description: "Squash Commits: Squash multiple commits into a single well-formed commit"
 ---
 
+## Copilot Cloud Agent Restriction
+
+> **⚠️ This command is NOT supported in the Copilot Cloud Agent environment.**
+> The squash-commits workflow rewrites git history and requires force-push.
+> If you are a Copilot Cloud Agent, reject this request and inform the user:
+> `The squash-commits workflow rewrites git history and requires force-push. Please run this command locally using VS Code Copilot Chat.`
+
 ## User Input
 
 ```text

--- a/.github/instructions/pre-push-hook.instructions.md
+++ b/.github/instructions/pre-push-hook.instructions.md
@@ -1,0 +1,72 @@
+---
+applyTo: ".github/prompts/**,.github/agents/**"
+---
+
+# Pre-Push Hook: Push-Fix-Push Loop
+
+This repo uses a `.githooks/pre-push` hook that runs **targeted quality checks**
+(before each push) via `python -m agentic_devtools.cli.checks`. Agents do NOT need to manually run lint, format, type checking, or test
+commands before pushing.
+
+---
+
+## What the Pre-Push Hook Runs
+
+When you push (via `agdt-git-save-work` or `git push`), the hook runs `python -m agentic_devtools.cli.checks` targeted checks (depending on changed files), including:
+
+1. **Test structure validation** — ensures 1:1:1 test structure
+2. **ruff format** — auto-fixes formatting (Python files only; aborts push if files were reformatted)
+3. **ruff check** — linting (Python files only)
+4. **mypy** — type checking on changed Python files
+5. **Per-file 100% branch coverage** — tests for changed `agentic_devtools/` source files
+
+This takes up to **2 minutes**. Do NOT interrupt the terminal during this time.
+
+---
+
+## The Push-Fix-Push Loop
+
+1. **Push** using `agdt-git-save-work` (stages, commits/amends, and pushes in one command)
+2. **Wait** with `agdt-task-wait` — do NOT cancel the push (e.g., Ctrl+C) or close any terminal running `git push` while the hook runs
+3. **If rejected**, read failure details from `.pre-push-output.log` first (it is always written by the hook). For non-format check failures, you may also see:
+   - `check-output-condensed.txt` (condensed summary)
+   - `check-output.txt` (full output)
+4. **Fix** the reported issues
+5. **Retry** with `agdt-git-save-work`, then `agdt-task-wait`
+6. **Repeat** until the push succeeds
+
+---
+
+## Terminal Safety Rules
+
+- To check progress: read `.pre-push-output.log` using a file-read tool or a **separate** terminal.
+- After a failed push, read `check-output-condensed.txt` / `check-output.txt` for failure details.
+- **Never poll the push terminal for status.**
+
+---
+
+## What NOT to Do
+
+- ❌ Do NOT manually run `ruff format`, `ruff check`, or `mypy` before pushing
+- ❌ Do NOT run `agdt-test` or `agdt-test-quick` as a pre-push validation step
+- ❌ Do NOT use `--no-verify` to bypass the hook
+- ❌ Do NOT run `agdt-git-force-push` after a normal `agdt-git-save-work` run (unless you intentionally used `--skip-push` and need a standalone force-push)
+
+---
+
+## `agdt-git-save-work` vs `agdt-git-force-push`
+
+| Command | What it does | When to use |
+|---------|--------------|-------------|
+| `agdt-git-save-work` | Stages changes via `git add .` (run from the repo root; note: deletions require `git add -A` + `agdt-git-save-work --skip-stage`), commits/amends, and pushes (auto force-push when needed) | Default for almost all workflows; use for the standard push-fix-push loop |
+| `agdt-git-force-push` | Force-pushes only (no staging, no committing) | **Only** when you need a standalone force-push after history rewriting without creating/amending a commit (e.g., squash-commits Phase 5 after Phase 3 used `git reset --soft` + `agdt-git-save-work --skip-push`) |
+
+---
+
+## Ensure Hooks Are Enabled
+
+```bash
+git config core.hooksPath .githooks
+```
+
+(If you’re not seeing the hook run, ensure `core.hooksPath` is set as above — Copilot environments configure this via `copilot-setup-steps.yml`, but local clones may not.)

--- a/.github/instructions/workflow-development.instructions.md
+++ b/.github/instructions/workflow-development.instructions.md
@@ -16,29 +16,28 @@ the identical process below.
    (e.g. `fix/1234/fix-save-work-amend` or `feature/1234/add-webhook-support`).
 2. Implement the changes.
 3. Update or create tests to cover all modified code paths. Ensure both success AND failure branches are tested.
-4. Run targeted checks on your changed files:
-   - `ruff check <files> --no-fix` (lint)
-   - `ruff format --check <files>` (format — auto-fix with `ruff format <files>` if needed)
-   - `python -m mypy <source-files> --ignore-missing-imports --follow-imports=silent` (type check)
-   - `agdt-test-pattern <test-files> --no-cov` (unit tests pass — **never** run `pytest` directly;
-     `agdt-test-pattern` runs synchronously and is the right tool for targeted checks; use
-     `agdt-test` / `agdt-test-quick` for full-suite runs, which go through the background-task system)
+4. Do NOT manually run `ruff`, `mypy`, or the full test suite before pushing —
+   the pre-push hook runs **targeted** checks based on changed files (lint/format/mypy/coverage as applicable).
+   See `.github/instructions/pre-push-hook.instructions.md` for the push-fix-push loop pattern.
 
 ---
 
 ## Push Phase (Pre-Push Hook)
 
-1. Stage, commit, and push using `agdt-git-save-work` (never `git commit` or `git push` directly —
-   this enforces the single-commit-per-PR policy and runs as a background task). Ensure hooks are
-   enabled (`git config core.hooksPath .githooks`) so the push runs the pre-push hook checks.
-2. If the hook fails, read `.pre-push-output.log` in the repo root to see what failed;
-   if available, also review `check-output-condensed.txt` (or `check-output.txt`)
-   for condensed/full failure details. Then fix the issues and rerun `agdt-git-save-work`.
+1. Commit and push using `agdt-git-save-work` (stages, commits/amends, AND pushes — all
+   in one smart command based on branch history), then wait with `agdt-task-wait`. Never use `git commit` or `git push` directly.
+   Ensure hooks are enabled (`git config core.hooksPath .githooks`) so the push runs the pre-push hook checks.
+2. If the hook fails, read `check-output-condensed.txt` (or `check-output.txt` / `.pre-push-output.log`)
+   from the repo root to see what failed. Fix the issues and rerun `agdt-git-save-work`, then `agdt-task-wait`.
 3. Do NOT use `--no-verify` to bypass the hook. The hook must pass.
+4. Do NOT run `agdt-git-force-push` after `agdt-git-save-work` — it already handles force-push
+   when amending an existing commit.
+
+See `.github/instructions/pre-push-hook.instructions.md` for the full push-fix-push loop pattern.
 
 ### Terminal Rules for Push
 
-- **CRITICAL: Do NOT send any commands to the terminal running `git push` while the pre-push hook is executing.** Sending any input will interrupt the hook and you must retry.
+- **CRITICAL: Do NOT cancel the push (e.g., Ctrl+C) or close the terminal running `git push` while the pre-push hook is executing.** If interrupted, rerun the push.
 - To check progress: read `.pre-push-output.log` from the repo root using a file-read tool or a **separate** terminal.
 - If you accidentally interrupt the push, rerun `agdt-git-save-work` to retry (never use raw `git push`/`git push --force-with-lease`).
 

--- a/.github/prompts/agdt.address-copilot-review.prompt.md
+++ b/.github/prompts/agdt.address-copilot-review.prompt.md
@@ -18,10 +18,15 @@ Follow this workflow systematically, completing each phase before proceeding to 
 | Reply to review comments | `agdt-gh-reply-to-review-comments` | `gh api .../comments/{id}/replies` per comment |
 | Resolve review threads | `agdt-gh-resolve-review-threads` | GraphQL `resolveReviewThread` mutation per thread |
 | Request Copilot re-review | `agdt-gh-request-copilot-review` | `gh api .../requested_reviewers -X POST` |
-| Run tests | `agdt-test` + `agdt-task-wait` | _Do not run `pytest` directly; always use `agdt-test` commands._ |
 | Stage changes | `agdt-git-stage` | `git add` |
 | Commit & push | `agdt-git-save-work` | `git commit` + `git push` |
-| Force push | `agdt-git-force-push` | `git push --force-with-lease` |
+
+> `agdt-git-save-work` stages, commits (or amends), AND pushes in one smart command.
+> It auto-detects when force-push is needed (e.g., amending). You do NOT need to run
+> `agdt-git-force-push` separately.
+>
+> See `.github/instructions/pre-push-hook.instructions.md` for the push-fix-push loop pattern
+> (the hook runs **targeted** checks based on changed files — do NOT run `agdt-test`, `ruff`, or `mypy` manually as a pre-push step).
 
 The `agdt-*` commands provide: centralized state tracking, consistent formatting, and background
 task management.
@@ -119,18 +124,8 @@ Document a triage table:
 ## Phase 4: Make Changes for Addressable Comments
 
 Edit files to address every comment classified as **addressable**. After **all** edits are
-complete, verify with tests, then commit and push once (not per-comment).
-
-### Verify Changes
-
-Run the test suite before committing to ensure edits don't break anything:
-
-```bash
-agdt-test
-agdt-task-wait
-```
-
-If tests fail, fix the issues before proceeding.
+complete, commit and push once (not per-comment). The pre-push hook will run the targeted
+checks that apply to the changed files.
 
 ### Resolve the GitHub Issue Key
 
@@ -201,13 +196,25 @@ REMOTE_SHA=$(gh pr view {pr_number} --repo {owner}/{repo} --json headRefOid --jq
 REMOTE_SHA_SHORT=$(echo "$REMOTE_SHA" | cut -c1-7)
 ```
 
-Compare `REMOTE_SHA` with `COMMIT_FULL`. If they do not match:
+Compare `REMOTE_SHA` with `COMMIT_FULL`. If they do not match, run the following retry sequence:
 
-1. Print `⚠️ Push verification failed — remote head ({REMOTE_SHA_SHORT}) ≠ local ({COMMIT_SHORT}). Retrying push.`
-2. Run `agdt-git-force-push` and `agdt-task-wait`.
-3. Re-verify with the same `gh pr view` command.
-4. If the SHAs still do not match after the retry, **stop** and report the failure
-   to the user.
+```bash
+# 1. Print a warning
+echo "⚠️ Push verification failed — remote head ≠ local. Retrying push."
+
+# 2. Retry — agdt-git-save-work auto-detects amend + force-push
+agdt-git-save-work
+agdt-task-wait
+
+# 3. Refresh local commit hash (it may have changed due to amend)
+COMMIT_FULL=$(git log -1 --format="%H")
+COMMIT_SHORT=$(git log -1 --format="%h")
+
+# 4. Re-verify
+REMOTE_SHA=$(gh pr view {pr_number} --repo {owner}/{repo} --json headRefOid --jq '.headRefOid')
+```
+
+If the SHAs still do not match after the retry, **stop** and report the failure to the user.
 
 ### Edge Case: No Addressable Comments
 

--- a/.github/prompts/agdt.pr-merge-manager.prompt.md
+++ b/.github/prompts/agdt.pr-merge-manager.prompt.md
@@ -19,9 +19,12 @@ Copilot review feedback, and merges the PR once all gates are green.
 | Re-run stale checks | `agdt-gh-rerun-checks` | `gh api .../actions/runs/{id}/rerun` |
 | Approve PR | `agdt-gh-pr-approve` | `gh pr review --approve` + verification |
 | Merge PR | `agdt-gh-pr-merge` | `gh pr merge --rebase` + verification |
-| Run tests | `agdt-test` + `agdt-task-wait` | _Do not run `pytest` directly._ |
 | Commit & push | `agdt-git-save-work` | `git commit` + `git push` |
-| Force push | `agdt-git-force-push` | `git push --force-with-lease` |
+
+> `agdt-git-save-work` stages, commits (or amends), AND pushes in one smart command.
+> After running it, wait with `agdt-task-wait` for the push + pre-push hook checks to finish.
+> The pre-push hook runs **targeted** checks based on changed files.
+> See `.github/instructions/pre-push-hook.instructions.md` for the push-fix-push loop pattern.
 
 ---
 

--- a/.github/prompts/agdt.resolve-merge-conflicts.prompt.md
+++ b/.github/prompts/agdt.resolve-merge-conflicts.prompt.md
@@ -10,14 +10,18 @@ You are a senior software engineer resolving merge conflicts. Follow this workfl
 
 | Operation | Preferred (agdt-*) | Fallback (raw) |
 |-----------|-------------------|----------------|
-| Run tests | `agdt-test` + `agdt-task-wait` | _Do not run `pytest` directly; always use `agdt-test` commands._ |
-| Stage changes | `agdt-git-stage` | `git add` |
-| Commit | `agdt-git-save-work` | `git commit` |
-| Push | `agdt-git-push` | `git push` |
+| Stage changes (new/modified files) | `agdt-git-stage` | `git add .` |
+| Stage all + commit + push | `agdt-git-save-work` | `git add -A` + `git commit` + `git push` |
 | Get PR context | — | `gh pr view` |
 | List GitHub issues | — | `gh issue list` |
 
 The `agdt-*` commands provide: state tracking, consistent formatting, and background task management.
+
+> `agdt-git-save-work` stages changes via `git add .` (run it from the repo root to cover the whole repo; note that `git add .` does **not** stage deletions), then commits/amends and pushes.
+> `agdt-git-stage` likewise stages via `git add .` (repo-root recommended; deletions require `git add -A` or `git add -u`).
+> For selective/full-repo staging (including deletions), run `git add <file>` (or `git add -A`) and then `agdt-git-save-work --skip-stage`.
+> After running `agdt-git-save-work`, you MUST wait with `agdt-task-wait` for the push + pre-push hook checks to finish.
+> See `.github/instructions/pre-push-hook.instructions.md` for the push-fix-push loop pattern.
 
 ---
 
@@ -191,10 +195,21 @@ jq . path/to/file.json
 5. Ensure imports/dependencies are included for all merged code
 
 ```bash
-# After resolution, verify code compiles and tests pass
-# Use agentic-devtools for test execution (always — do not run pytest directly)
-agdt-test                    # Runs full test suite (background task)
-agdt-task-wait               # Wait for test results
+# After resolving all conflicts, finalise and push.
+#
+# IMPORTANT: Check whether MERGE_HEAD exists — if so, you are completing a merge commit
+# and must NOT use agdt-git-save-work (it amends, which would discard the merge parents).
+#
+# Case A — completing a merge commit (MERGE_HEAD exists):
+git merge --continue        # finalise the merge commit (opens editor; use --no-edit to skip)
+# or equivalently: git commit --no-edit
+agdt-git-push               # push the true merge commit; the pre-push hook runs targeted checks
+agdt-task-wait
+
+# Case B — regular (non-merge) commit (MERGE_HEAD does not exist):
+# agdt-git-save-work handles staging, commit/amend, and push in one step.
+agdt-git-save-work
+agdt-task-wait
 ```
 
 ### Configuration Files (`.yaml`, `.tf`, `.json` config)
@@ -259,11 +274,6 @@ grep -e '^<<<<<<< ' -e '^=======$' -e '^>>>>>>> ' path/to/file
 # For JSON files - validate syntax (dependency-free)
 python -m json.tool path/to/file.json >/dev/null 2>&1 || echo "JSON INVALID"
 
-# Run tests to verify resolution didn't break anything
-# Use agentic-devtools (always — do not run pytest directly)
-agdt-test                    # Full test suite
-agdt-task-wait               # Wait for results
-
 # Mark file as resolved
 git add path/to/file
 ```
@@ -280,21 +290,11 @@ git diff --name-only --diff-filter=U
 git diff --cached
 
 # Complete the merge (only if all conflicts resolved)
-# Option A: Use agentic-devtools (preferred - but skip rebase/push automation during merge completion)
-agdt-set commit_message "chore([#<issue-number>](https://github.com/ayaiayorg/agentic-devtools/issues/<issue-number>)): resolve merge conflicts from main into <branch-name>
-
-[#<issue-number>](https://github.com/ayaiayorg/agentic-devtools/issues/<issue-number>)"
-
-# During a merge commit, disable auto-push and skip the rebase step
-agdt-set skip_push true
-agdt-git-save-work --skip-rebase
-
-# After the merge commit is created and reviewed, push explicitly
-agdt-git-push
-
-# Option B: Raw git (fallback if agdt not available)
-git commit
-git push
+# IMPORTANT: Do NOT use agdt-git-save-work here — it amends and would discard merge parents.
+# Use git merge --continue (or git commit) to create the true merge commit, then push.
+git merge --continue    # finalise merge commit (opens editor); or: git commit --no-edit
+agdt-git-push           # push the true merge commit; the pre-push hook runs targeted checks
+agdt-task-wait
 ```
 
 ---
@@ -330,19 +330,11 @@ Sometimes code merges cleanly but produces incorrect behavior (no markers, but i
 
 **Detection:**
 
-```bash
-# Run tests to detect semantic conflicts
-agdt-test              # Preferred: full test suite via agentic-devtools
-agdt-task-wait         # Wait for results
+The pre-push hook runs targeted checks when you push, but it only runs tests when it detects
+changed Python sources/tests. If you suspect semantic conflicts before pushing, review runtime
+behavior and consider running relevant tests locally (optional) before pushing.
 
-# Or use quick tests for faster feedback
-agdt-test-quick        # Subset of critical tests
-```
-
-- Review runtime behavior if tests pass but functionality seems wrong
-- Check for renamed variables/functions that may cause silent breakage
-
-**Guideline:** Always run the full test suite (`agdt-test`) after completing a merge, even when conflicts appeared simple.
+**Guideline:** Always push after completing a merge — the pre-push hook runs targeted checks for the changed files and can catch many merge regressions early.
 
 ### Auto-Generated Files
 
@@ -385,8 +377,7 @@ After completing all resolutions, document your work:
 
 ### Verification
 
-- [ ] All tests pass (`agdt-test` + `agdt-task-wait`)
-- [ ] Build succeeds
+- [ ] Push succeeds (pre-push hook completes and any targeted checks for the changed files pass)
 - [ ] No conflict markers remain
 - [ ] Reviewed diff of all resolved files
 ```

--- a/.github/prompts/agdt.squash-commits.prompt.md
+++ b/.github/prompts/agdt.squash-commits.prompt.md
@@ -6,19 +6,28 @@ to the next.
 
 ---
 
+> **⚠️ COPILOT CLOUD AGENT RESTRICTION**: This workflow rewrites git history and requires force-pushing (`git push --force-with-lease`).
+> If you are a Copilot Cloud Agent (coding agent), you MUST reject this command and inform the user with exactly this message:
+>
+> `The squash-commits workflow rewrites git history and requires force-push. Please run this command locally using VS Code Copilot Chat.`
+
+---
+
 ## Tooling Priority
 
 **Always prefer `agdt-*` commands** from agentic-devtools over raw git commands:
 
 | Operation | Preferred (agdt-*) | Fallback (raw) |
 |-----------|-------------------|----------------|
-| Run tests | `agdt-test` + `agdt-task-wait` | _Do not run `pytest` directly; always use `agdt-test` commands._ |
 | Stage changes | `agdt-git-stage` | `git add` |
 | Commit | `agdt-git-save-work` | `git commit` |
 | Push (force) | `agdt-git-force-push` | `git push --force-with-lease` |
 | List GitHub issues | — | `gh issue list` |
 
 The `agdt-*` commands provide: centralized state tracking, consistent formatting, and background task management.
+
+> **Do NOT manually run lint, format, mypy, or test commands.** The pre-push hook runs targeted checks
+> based on changed files (ruff/mypy/coverage for relevant Python changes). See Phase 5 for the push-fix-push loop pattern.
 
 ---
 
@@ -354,14 +363,6 @@ REPORT_EOF
 Populate the `"warnings"` array with any warnings from the safety detection phase
 (e.g., `"merge commits detected"`, `"merge-base changed"`).
 
-### Run Tests
-
-```bash
-# Use agentic-devtools (always — do not run pytest directly)
-agdt-test
-agdt-task-wait
-```
-
 ### Verification Summary
 
 Confirm all items pass:
@@ -373,18 +374,24 @@ Confirm all items pass:
 - [ ] Branch merge-base is unchanged from Phase 1 capture
 - [ ] No unintended files staged or lost
 - [ ] **Diff hashes match** (pre-squash and post-squash are content-equivalent)
-- [ ] Tests pass (if applicable)
 - [ ] Verification report written (if a report file was requested)
+
+> **Note**: Tests are NOT run manually in this phase. The pre-push hook in Phase 5 runs targeted checks
+> based on changed files (including lint/format/mypy and per-file coverage for relevant Python changes).
+> This avoids duplicating work.
 
 ---
 
-## Phase 5: Push
+## Phase 5: Push (with Pre-Push Hook)
 
-Force-push the squashed branch (since history was rewritten).
+Force-push the squashed branch. The **pre-push hook** runs targeted checks based on changed files
+(e.g., test structure validation (always), plus ruff format/check, mypy, and per-file coverage for relevant Python changes). This can
+take up to **2 minutes**.
 
 ```bash
 # Preferred: agentic-devtools (uses --force-with-lease internally)
 agdt-git-force-push
+agdt-task-wait
 
 # Fallback: Use --force-with-lease for safety (NEVER use bare --force)
 git push --force-with-lease
@@ -394,6 +401,27 @@ git push --force-with-lease
 > refuses to push if the remote has commits you haven't seen, preventing accidental overwrites
 > of collaborators' work. The `agdt-git-force-push` command already uses `--force-with-lease`
 > internally.
+
+### Terminal Safety Rules
+
+- To check progress: read `.pre-push-output.log` from the repo root using a file-read tool or a **separate** terminal.
+- **Never poll the push terminal for status.**
+
+### Push-Fix-Push Loop
+
+If the pre-push hook rejects the push:
+
+1. **Read the failure details** from `.pre-push-output.log` first (always written by the hook).
+   For non-format check failures, also review `check-output-condensed.txt` (condensed) or `check-output.txt` (full output) in the repo root.
+2. **Fix the reported issues** (e.g., lint errors, coverage gaps, type errors).
+3. **Clear Phase 3 skip flags, then stage + amend + push** using `agdt-git-save-work --skip-rebase`, then wait with
+   `agdt-task-wait` (run `agdt-delete skip_stage` and `agdt-delete skip_push` first if they were set earlier).
+4. **Repeat** until the push succeeds.
+
+> **Do NOT use `--no-verify`** to bypass the hook. The hook must pass.
+>
+> **Do NOT manually run** `ruff`, `mypy`, `pytest`, or `agdt-test` before pushing — the
+> pre-push hook handles all checks. Running them manually is inefficient and duplicates work.
 
 ---
 


### PR DESCRIPTION
## Changes

- **Removed manual test execution** from Phase 4 verification — the pre-push hook now serves as the push-time validation step by running the **targeted** checks that apply to the changed files
- **Replaced Phase 5** with a push-fix-push loop pattern:
  1. Push (the pre-push hook runs the relevant targeted checks for the changed files)
  2. If rejected, read `check-output-condensed.txt` for failure details
  3. Fix issues, amend commit, retry push
- **Added terminal safety rules** — do not cancel the push or close the push terminal while the hook executes; monitor via `check-output-condensed.txt` from a separate terminal or file-read tool
- **Added Copilot Cloud Agent restriction** — cloud agents cannot force-push, so they must reject this command and inform the user to run locally
- **Updated agent file** (`agdt.squash-commits.agent.md`) with cloud agent rejection guidance
- **Aligned related prompts/instructions** so they describe the pre-push hook as running targeted checks rather than implying unconditional lint/type/test/coverage verification

## Rationale

Running `agdt-test` + `agdt-task-wait` manually before pushing duplicates work because the pre-push hook already runs the relevant targeted checks for the changed files. This aligns with the pattern used by other workflows (e.g., `address-copilot-review`, `workflow-development` instructions) while keeping the wording accurate about what the hook actually guarantees.