### PR TITLE
fix(#2056): fix PR description newline truncation on Windows and add Jinja2 PR templates

### DIFF
--- a/agentic_devtools/cli/azure_devops/commands.py
+++ b/agentic_devtools/cli/azure_devops/commands.py
@@ -219,6 +219,26 @@ def update_review_narrative(pull_request_id: int, content: str) -> None:
     print("Review Narrative updated successfully.")
 
 
+def _escape_for_cmd(value: str) -> str:
+    """Escape cmd.exe metacharacters for safe use in Windows arguments.
+
+    Note: create_pull_request executes `az` via `shell=True` on Windows, and passes
+    args as a list. Avoid embedding literal quote characters into individual args;
+    instead use cmd-native escaping (caret) plus percent doubling.
+    """
+    if sys.platform != "win32":
+        return value
+
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    single_line = " ".join(part for part in normalized.split("\n") if part)
+
+    escaped = single_line.replace("^", "^^").replace("%", "%%")
+    for ch in ("&", "|", "<", ">"):
+        escaped = escaped.replace(ch, f"^{ch}")
+    escaped = escaped.replace('"', '^"')
+    return escaped
+
+
 def add_pull_request_comment() -> None:
     """
     Add a new comment to a pull request.
@@ -363,11 +383,14 @@ def create_pull_request() -> None:
     - draft (optional): Whether to create as draft, defaults to True
     - dry_run (optional): Preview without making API calls
 
+    The PR title is resolved from ``.agdt/config/pr-title-template.j2``
+    if it exists and renders successfully; otherwise falls back to stripping
+    Markdown links from the ``title`` state key.
+
     The PR description is resolved via the shared PR body template
-    (``resolve_pr_body()``).  If ``.agdt/config/pull-request-template.md``
-    exists it is used as the template with ``{{fullCommitMessage}}``
-    substituted; otherwise the raw commit message is used as the body.
-    Run ``agdt-init-pr-template`` once to create the template file.
+    (``resolve_pr_body()``).  If ``.agdt/config/pull-request-template.j2``
+    exists it is used as the template; otherwise the
+    raw commit message is used as the body.
 
     Usage:
         agdt-set source_branch "feature/PROJECT-1234/my-feature"
@@ -388,8 +411,11 @@ def create_pull_request() -> None:
         print('Error: No title found. Use: agdt-set title "PR title"', file=sys.stderr)
         sys.exit(1)
 
-    # Strip Markdown links from title
-    title = convert_to_pull_request_title(title)
+    # Resolve PR title: try template first, fall back to link-stripping
+    from ..pr_template import resolve_pr_title
+
+    rendered_title = resolve_pr_title()
+    title = rendered_title if rendered_title else convert_to_pull_request_title(title)
 
     # Get optional values
     from ..pr_template import resolve_pr_body
@@ -432,6 +458,13 @@ def create_pull_request() -> None:
 
     print(f"Creating pull request for '{source_branch}' -> '{target_branch}'...")
 
+    safe_source_branch = _escape_for_cmd(source_branch)
+    safe_target_branch = _escape_for_cmd(target_branch)
+    safe_title = _escape_for_cmd(title)
+    safe_organization = _escape_for_cmd(config.organization)
+    safe_project = _escape_for_cmd(config.project)
+    safe_repository = _escape_for_cmd(config.repository)
+
     # Build az repos pr create command
     cmd = [
         "az",
@@ -439,17 +472,17 @@ def create_pull_request() -> None:
         "pr",
         "create",
         "--source-branch",
-        source_branch,
+        safe_source_branch,
         "--target-branch",
-        target_branch,
+        safe_target_branch,
         "--title",
-        title,
+        safe_title,
         "--organization",
-        config.organization,
+        safe_organization,
         "--project",
-        config.project,
+        safe_project,
         "--repository",
-        config.repository,
+        safe_repository,
         "--output",
         "json",
     ]
@@ -457,10 +490,48 @@ def create_pull_request() -> None:
     if draft:
         cmd.append("--draft")
 
+    desc_temp_file_path = None
     if description:
-        cmd.extend(["--description", description])
+        if sys.platform == "win32":
+            # Use @filepath on Windows to avoid cmd.exe truncating multiline
+            # values when az is executed via shell=True for .cmd scripts.
+            import tempfile
 
-    result = run_safe(cmd, capture_output=True, text=True, env=env)
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    suffix=".md",
+                    prefix="agdt-pr-desc-",
+                    delete=False,
+                    encoding="utf-8",
+                ) as desc_temp_file:
+                    desc_temp_file_path = desc_temp_file.name
+                    desc_temp_file.write(description)
+
+                cmd.extend(["--description", _escape_for_cmd(f"@{desc_temp_file_path}")])
+            except Exception:
+                if desc_temp_file_path is not None:
+                    try:
+                        os.unlink(desc_temp_file_path)
+                    except OSError:
+                        pass
+                    else:
+                        desc_temp_file_path = None
+                raise
+        else:
+            cmd.extend(["--description", description])
+
+    try:
+        result = run_safe(cmd, capture_output=True, text=True, env=env)
+    finally:
+        if desc_temp_file_path is not None:
+            try:
+                os.unlink(desc_temp_file_path)
+            except OSError as exc:  # pragma: no cover
+                print(
+                    f"Warning: Could not delete temporary PR description file {desc_temp_file_path}: {exc}",
+                    file=sys.stderr,
+                )
 
     if result.returncode != 0:
         print(f"Error creating PR: {result.stderr}", file=sys.stderr)

--- a/agentic_devtools/cli/pr_template.py
+++ b/agentic_devtools/cli/pr_template.py
@@ -1,27 +1,30 @@
-"""
-PR body template utilities.
+"""PR body and title template utilities.
 
-Provides functions to resolve the PR body from a user-managed template file
-with commit message interpolation and fallback chain.
+Provides functions to resolve the PR body and title from user-managed
+Jinja2 template files (``.j2``) with variable interpolation and fallback chain.
 """
 
 import sys
 from pathlib import Path
 
+import jinja2
+import jinja2.meta
+import jinja2.sandbox
+
 from ..state import get_value
 from .git.core import STATE_LAST_COMMIT_MESSAGE, run_git
 
 # Template location relative to git root
-TEMPLATE_RELATIVE_PATH = ".agdt/config/pull-request-template.md"
+TEMPLATE_RELATIVE_PATH = ".agdt/config/pull-request-template.j2"
 
-# Placeholder for commit message interpolation
-PLACEHOLDER = "{{fullCommitMessage}}"
+# PR title template location relative to git root
+PR_TITLE_TEMPLATE_PATH = ".agdt/config/pr-title-template.j2"
 
 # Fallback literal when no commit message is available
 FALLBACK_MESSAGE = "No commit message could be found."
 
-# Default template content (German-language operational checklist)
-DEFAULT_TEMPLATE_CONTENT = (
+# Default template content (German-language operational checklist) - Jinja2 version
+DEFAULT_TEMPLATE_CONTENT_J2 = (
     "# Pull Request\n"
     "\n"
     "## **Checkliste für Schnittmenge mit dem Betrieb**\n"
@@ -67,8 +70,11 @@ DEFAULT_TEMPLATE_CONTENT = (
     "\n"
     "## Zusatzinformationen\n"
     "\n"
-    f"{PLACEHOLDER}\n"
+    "{{ fullCommitMessage }}\n"
 )
+
+# Default PR title template content
+DEFAULT_PR_TITLE_TEMPLATE = "{{ issueType }}({{ issueKey }}): {{ commitMessageTitle }}\n"
 
 
 def resolve_main_ref() -> str | None:
@@ -91,7 +97,7 @@ def resolve_main_ref() -> str | None:
 
 
 def get_template_path(git_root: Path | None = None) -> Path:
-    """Get the absolute path to the PR template file.
+    """Get the absolute path to the PR body template file.
 
     Args:
         git_root: Optional explicit git root path. If ``None``, resolved
@@ -109,6 +115,26 @@ def get_template_path(git_root: Path | None = None) -> Path:
             git_root = Path(result.stdout.strip())
 
     return git_root / TEMPLATE_RELATIVE_PATH
+
+
+def get_pr_title_template_path(git_root: Path | None = None) -> Path:
+    """Get the absolute path to the PR title template file.
+
+    Args:
+        git_root: Optional explicit git root path. If ``None``, resolved
+            via ``git rev-parse --show-toplevel``.
+
+    Returns:
+        Absolute path to the PR title template file.
+    """
+    if git_root is None:
+        result = run_git("rev-parse", "--show-toplevel", check=False)
+        if result.returncode != 0:
+            git_root = Path.cwd()
+        else:
+            git_root = Path(result.stdout.strip())
+
+    return git_root / PR_TITLE_TEMPLATE_PATH
 
 
 def resolve_full_commit_message() -> str:
@@ -143,12 +169,11 @@ def resolve_full_commit_message() -> str:
 
 
 def resolve_pr_body() -> str:
-    """Resolve the PR body from template with commit message interpolation.
+    """Resolve the PR body from the Jinja2 template with commit message interpolation.
 
-    Loads the template file and replaces ``{{fullCommitMessage}}`` with the
-    resolved commit message. If the template is missing, warns and returns
-    just the commit message. If the template has no placeholder, returns
-    the template content as-is.
+    Renders ``.agdt/config/pull-request-template.j2`` with ``fullCommitMessage``
+    as a template variable. If the template is missing, warns and returns
+    just the commit message.
 
     Returns:
         The final PR body string.
@@ -174,15 +199,126 @@ def resolve_pr_body() -> str:
     if not content.strip():
         return resolve_full_commit_message()
 
-    if PLACEHOLDER in content:
-        message = resolve_full_commit_message()
-        return content.replace(PLACEHOLDER, message)
+    return _render_j2_body_template(content)
 
-    return content
+
+def _render_j2_body_template(content: str) -> str:
+    """Render a Jinja2 PR body template.
+
+    Args:
+        content: The template content string.
+
+    Returns:
+        Rendered PR body string.
+    """
+    message = resolve_full_commit_message()
+    context = {"fullCommitMessage": message}
+
+    try:
+        env = jinja2.sandbox.SandboxedEnvironment(
+            loader=jinja2.BaseLoader(),
+            autoescape=False,
+            keep_trailing_newline=True,
+            undefined=jinja2.Undefined,
+        )
+
+        # Warn on unresolved variables (they will render as empty with jinja2.Undefined)
+        ast = env.parse(content)
+        referenced = jinja2.meta.find_undeclared_variables(ast)
+        known_names = set(env.globals.keys())
+        missing = referenced - set(context.keys()) - known_names
+        for var in sorted(missing):
+            print(
+                f"Warning: PR body template variable '{var}' is unresolved — it will render as empty in the PR body",
+                file=sys.stderr,
+            )
+
+        tmpl = env.from_string(content)
+        rendered = tmpl.render(context)
+    except jinja2.TemplateSyntaxError as exc:
+        print(
+            f"Warning: PR body template has syntax error: {exc}. Using commit message as PR body.",
+            file=sys.stderr,
+        )
+        return message
+    except (jinja2.UndefinedError, jinja2.TemplateRuntimeError) as exc:  # pragma: no cover
+        print(
+            f"Warning: PR body template rendering failed: {exc}. Using commit message as PR body.",
+            file=sys.stderr,
+        )
+        return message
+
+    return rendered
+
+
+def resolve_pr_title() -> str | None:
+    """Resolve the PR title from the Jinja2 title template.
+
+    Renders ``.agdt/config/pr-title-template.j2`` using the same variable
+    resolution as the commit template (issueType, issueKey, commitMessageTitle).
+
+    Returns:
+        Rendered PR title string, or ``None`` if the template is missing
+        or rendering fails (caller should fall back to existing title logic).
+    """
+    template_path = get_pr_title_template_path()
+
+    if not template_path.exists():
+        return None
+
+    try:
+        content = template_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(
+            f"Warning: Cannot read PR title template: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+    if not content.strip():
+        return None
+
+    # Build render context from state (reuse commit template variable resolution)
+    from .git.commit_template import _resolve_commit_title, _resolve_issue_key, _resolve_issue_type
+
+    context: dict[str, str] = {}
+
+    normalized_key, _raw_key = _resolve_issue_key()
+    if normalized_key is not None:
+        context["issueKey"] = normalized_key
+
+    issue_type = _resolve_issue_type()
+    if issue_type is not None:
+        context["issueType"] = issue_type
+
+    title = _resolve_commit_title()
+    if title is not None:
+        context["commitMessageTitle"] = title
+
+    try:
+        env = jinja2.sandbox.SandboxedEnvironment(
+            loader=jinja2.BaseLoader(),
+            autoescape=False,
+            keep_trailing_newline=False,
+            undefined=jinja2.StrictUndefined,
+        )
+        tmpl = env.from_string(content)
+        rendered = tmpl.render(context).strip()
+    except (jinja2.TemplateSyntaxError, jinja2.UndefinedError, jinja2.TemplateRuntimeError) as exc:
+        print(
+            f"Warning: PR title template rendering failed: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+    if not rendered:
+        return None
+
+    return rendered
 
 
 def init_pr_template() -> None:
-    """Create the default PR template if it does not exist.
+    """Create the default PR body template if it does not exist.
 
     CLI entry point for ``agdt-init-pr-template``.
     """
@@ -193,5 +329,61 @@ def init_pr_template() -> None:
         return
 
     template_path.parent.mkdir(parents=True, exist_ok=True)
-    template_path.write_text(DEFAULT_TEMPLATE_CONTENT, encoding="utf-8")
+    template_path.write_text(DEFAULT_TEMPLATE_CONTENT_J2, encoding="utf-8")
     print(f"Created PR template at {template_path}")
+
+
+def ensure_pr_title_template(git_root: Path) -> bool:
+    """Create the default PR title template if it does not exist.
+
+    Args:
+        git_root: Repository root path.
+
+    Returns:
+        ``True`` if the template was created, ``False`` if it already existed.
+    """
+    template_path = git_root / PR_TITLE_TEMPLATE_PATH
+    if template_path.is_file():
+        return False
+
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_text(DEFAULT_PR_TITLE_TEMPLATE, encoding="utf-8")
+    return True
+
+
+def ensure_pr_body_template(git_root: Path) -> bool:
+    """Create the default PR body template (.j2) if it does not exist.
+
+    If a legacy ``.md`` template exists, it is removed and replaced with the default
+    ``.j2`` template during setup.
+
+    Args:
+        git_root: Repository root path.
+
+    Returns:
+        ``True`` if a repo mutation occurred (default ``.j2`` created and/or legacy ``.md`` removed),
+        ``False`` if no changes were needed.
+    """
+    template_path = git_root / TEMPLATE_RELATIVE_PATH
+
+    legacy_path = git_root / ".agdt/config/pull-request-template.md"
+    legacy_backup_path = git_root / ".agdt/config/pull-request-template.md.bak"
+    legacy_removed = False
+    if legacy_path.is_file():
+        try:
+            if not legacy_backup_path.exists():
+                legacy_backup_path.parent.mkdir(parents=True, exist_ok=True)
+                legacy_backup_path.write_bytes(legacy_path.read_bytes())
+            legacy_path.unlink()
+            legacy_removed = True
+        except OSError as exc:
+            print(
+                f"Warning: Could not migrate/remove legacy PR body template at {legacy_path}: {exc}",
+                file=sys.stderr,
+            )
+
+    if template_path.is_file():
+        return legacy_removed
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_text(DEFAULT_TEMPLATE_CONTENT_J2, encoding="utf-8")
+    return True

--- a/agentic_devtools/cli/setup/commands.py
+++ b/agentic_devtools/cli/setup/commands.py
@@ -944,6 +944,30 @@ def setup_cmd() -> None:
                 except Exception as exc:  # noqa: BLE001
                     print(f"  ⚠ Commit template setup failed ({exc}) — skipping", file=sys.stderr)
 
+                # Step 4: PR templates (title + body)
+                try:
+                    if not args.skip_templates:  # pragma: no cover — tested via unit tests on ensure_pr_*
+                        from agentic_devtools.cli.pr_template import (  # noqa: PLC0415
+                            ensure_pr_body_template,
+                            ensure_pr_title_template,
+                        )
+
+                        created_title = ensure_pr_title_template(git_root)
+                        if created_title:
+                            print("  ✓ Created default PR title template: .agdt/config/pr-title-template.j2")
+                            repo_mutations_succeeded = True
+                        else:
+                            print("  ℹ PR title template already exists")
+
+                        mutated_body = ensure_pr_body_template(git_root)
+                        if mutated_body:
+                            print("  ✓ Ensured PR body template is present: .agdt/config/pull-request-template.j2")
+                            repo_mutations_succeeded = True
+                        else:
+                            print("  ℹ PR body template already exists (no changes needed)")
+                except Exception as exc:  # noqa: BLE001  # pragma: no cover
+                    print(f"  ⚠ PR template setup failed ({exc}) — skipping", file=sys.stderr)
+
             # ── Script Generation Phase ────────────────────────────────
             print()
             print("─── Setup Script Generation ─────────────────────────────────")

--- a/tests/azure_devops/test_commands_api.py
+++ b/tests/azure_devops/test_commands_api.py
@@ -247,8 +247,12 @@ class TestCreatePullRequestActualCall:
     """Tests for create_pull_request with mocked subprocess calls."""
 
     @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_body", return_value="")
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_title", return_value=None)
     @patch("subprocess.run")
-    def test_successful_pr_creation(self, mock_run, temp_state_dir, clear_state_before, capsys):
+    def test_successful_pr_creation(
+        self, mock_run, _mock_title, _mock_body, temp_state_dir, clear_state_before, capsys
+    ):
         """Test successful PR creation."""
         # Mock az --version check
         mock_version = MagicMock()
@@ -275,8 +279,10 @@ class TestCreatePullRequestActualCall:
         assert "999" in captured.out
 
     @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_body", return_value="")
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_title", return_value=None)
     @patch("subprocess.run")
-    def test_pr_creation_failure(self, mock_run, temp_state_dir, clear_state_before, capsys):
+    def test_pr_creation_failure(self, mock_run, _mock_title, _mock_body, temp_state_dir, clear_state_before, capsys):
         """Test PR creation fails when az command fails."""
         # Mock az --version check
         mock_version = MagicMock()
@@ -305,8 +311,10 @@ class TestCreatePullRequestActualCall:
         assert "Error creating PR" in captured.err
 
     @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_body", return_value="PR description")
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_title", return_value=None)
     @patch("subprocess.run")
-    def test_pr_creation_with_description(self, mock_run, temp_state_dir, clear_state_before):
+    def test_pr_creation_with_description(self, mock_run, _mock_title, _mock_body, temp_state_dir, clear_state_before):
         """Test PR creation with description."""
         mock_version = MagicMock()
         mock_version.returncode = 0

--- a/tests/unit/cli/azure_devops/commands/test__escape_for_cmd.py
+++ b/tests/unit/cli/azure_devops/commands/test__escape_for_cmd.py
@@ -1,0 +1,54 @@
+"""Tests for agentic_devtools.cli.azure_devops.commands._escape_for_cmd."""
+
+from unittest.mock import patch
+
+from agentic_devtools.cli.azure_devops.commands import _escape_for_cmd
+
+
+class TestEscapeForCmd:
+    """Tests for the _escape_for_cmd helper function."""
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_doubles_percent_on_windows(self) -> None:
+        assert _escape_for_cmd("has%ISSUE%") == "has%%ISSUE%%"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "linux")
+    def test_noop_on_non_windows(self) -> None:
+        assert _escape_for_cmd("a&b|c%d") == "a&b|c%d"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_no_special_chars_unchanged_on_windows(self) -> None:
+        assert _escape_for_cmd("normal/branch-name") == "normal/branch-name"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_empty_string_on_windows(self) -> None:
+        assert _escape_for_cmd("") == ""
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_escapes_ampersand_with_caret_on_windows(self) -> None:
+        assert _escape_for_cmd("branch&name") == "branch^&name"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_escapes_pipe_with_caret_on_windows(self) -> None:
+        assert _escape_for_cmd("branch|name") == "branch^|name"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_escapes_less_than_with_caret_on_windows(self) -> None:
+        assert _escape_for_cmd("branch<name") == "branch^<name"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_escapes_greater_than_with_caret_on_windows(self) -> None:
+        assert _escape_for_cmd("branch>name") == "branch^>name"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_escapes_caret_by_doubling_on_windows(self) -> None:
+        assert _escape_for_cmd("branch^name") == "branch^^name"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_percent_doubled_and_metachar_escaped_together(self) -> None:
+        """When value has both % and a metachar, both escaping rules are applied."""
+        assert _escape_for_cmd("has%and&both") == "has%%and^&both"
+
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    def test_embedded_double_quote_and_metachar_use_caret_escaping(self) -> None:
+        assert _escape_for_cmd('branch"name&test') == 'branch^"name^&test'

--- a/tests/unit/cli/azure_devops/commands/test_create_pull_request.py
+++ b/tests/unit/cli/azure_devops/commands/test_create_pull_request.py
@@ -27,6 +27,21 @@ def _mock_resolve_pr_body():
         yield mock
 
 
+@pytest.fixture(autouse=True)
+def _mock_resolve_pr_title():
+    """Mock resolve_pr_title for create_pull_request tests.
+
+    The function is called internally by create_pull_request; these tests
+    focus on the Azure DevOps CLI interaction, not title template resolution.
+    Returns None so that the fallback (convert_to_pull_request_title) is used.
+    """
+    with patch(
+        "agentic_devtools.cli.pr_template.resolve_pr_title",
+        return_value=None,
+    ):
+        yield
+
+
 class TestCreatePullRequest:
     """Tests for create_pull_request command."""
 
@@ -140,6 +155,18 @@ class TestCreatePullRequest:
         captured = capsys.readouterr()
         # Title should have Markdown links stripped
         assert "Title: feature(PROJECT-1234): test" in captured.out
+
+    @patch("agentic_devtools.cli.pr_template.resolve_pr_title", return_value="feat(PROJ-99): rendered title")
+    def test_dry_run_uses_rendered_title_from_template(self, _mock_title, temp_state_dir, clear_state_before, capsys):
+        """Uses rendered title from template when available."""
+        state.set_value("source_branch", "feature/test")
+        state.set_value("title", "Original Title With [Links](http://x)")
+        state.set_dry_run(True)
+
+        azure_devops.create_pull_request()
+
+        captured = capsys.readouterr()
+        assert "Title: feat(PROJ-99): rendered title" in captured.out
 
     def test_dry_run_with_description(self, temp_state_dir, clear_state_before, capsys):
         """Test dry run shows description when provided."""
@@ -259,10 +286,12 @@ class TestCreatePullRequestActualCall:
 
         azure_devops.create_pull_request()
 
-        # Check that description was in the command
+        # On non-Windows platforms, description is passed directly.
         create_call = mock_run.call_args_list[2]
         cmd = create_call[0][0]
         assert "--description" in cmd
+        desc_index = cmd.index("--description")
+        assert cmd[desc_index + 1] == "PR description"
 
     @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
     @patch("subprocess.run")
@@ -340,3 +369,171 @@ class TestCreatePullRequestActualCall:
         assert "--description" in cmd
         desc_index = cmd.index("--description")
         assert cmd[desc_index + 1] == "Body from template"
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("os.unlink")
+    @patch("subprocess.run")
+    def test_pr_creation_with_description_uses_tempfile_on_windows(
+        self,
+        mock_run,
+        mock_unlink,
+        mock_named_temporary_file,
+        temp_state_dir,
+        clear_state_before,
+    ):
+        """Windows uses @filepath workaround for multiline-safe PR descriptions."""
+        mock_version = MagicMock()
+        mock_version.returncode = 0
+        mock_ext = MagicMock()
+        mock_ext.returncode = 0
+        mock_ext.stdout = "azure-devops"
+        mock_create = MagicMock()
+        mock_create.returncode = 0
+        mock_create.stdout = '{"pullRequestId": 999, "repository": {}}'
+        mock_run.side_effect = [mock_version, mock_ext, mock_create]
+
+        mock_temp_file = MagicMock()
+        mock_temp_file.name = r"C:\temp\agdt-pr-desc.md"
+        mock_named_temporary_file.return_value.__enter__.return_value = mock_temp_file
+
+        state.set_value("source_branch", "feature/test")
+        state.set_value("title", "Test PR")
+        state.set_value("description", "line one\nline two")
+
+        azure_devops.create_pull_request()
+
+        create_call = mock_run.call_args_list[2]
+        cmd = create_call[0][0]
+        desc_index = cmd.index("--description")
+        assert cmd[desc_index + 1] == r"@C:\temp\agdt-pr-desc.md"
+        mock_temp_file.write.assert_called_once_with("line one\nline two")
+        mock_unlink.assert_called_once_with(r"C:\temp\agdt-pr-desc.md")
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("os.unlink")
+    @patch("subprocess.run")
+    def test_pr_creation_escapes_cmd_visible_values_on_windows(
+        self,
+        mock_run,
+        mock_unlink,
+        mock_named_temporary_file,
+        temp_state_dir,
+        clear_state_before,
+    ):
+        """Windows escapes percent signs in all cmd.exe-visible az arguments."""
+        mock_version = MagicMock()
+        mock_version.returncode = 0
+        mock_ext = MagicMock()
+        mock_ext.returncode = 0
+        mock_ext.stdout = "azure-devops"
+        mock_create = MagicMock()
+        mock_create.returncode = 0
+        mock_create.stdout = '{"pullRequestId": 999, "repository": {}}'
+        mock_run.side_effect = [mock_version, mock_ext, mock_create]
+
+        mock_temp_file = MagicMock()
+        mock_temp_file.name = r"C:\temp\%USERNAME%\agdt-pr-desc.md"
+        mock_named_temporary_file.return_value.__enter__.return_value = mock_temp_file
+
+        state.set_value("source_branch", "feature/%USERPROFILE%/test")
+        state.set_value("target_branch", "release/%APPDATA%")
+        state.set_value("title", "Test %AZURE_DEVOPS_EXT_PAT%")
+        state.set_value("description", "line one\nline two")
+        state.set_value("organization", "https://dev.azure.com/%ORG%")
+        state.set_value("project", "%PROJECT%")
+        state.set_value("repository", "%REPO%")
+
+        azure_devops.create_pull_request()
+
+        create_call = mock_run.call_args_list[2]
+        cmd = create_call[0][0]
+
+        source_index = cmd.index("--source-branch")
+        target_index = cmd.index("--target-branch")
+        title_index = cmd.index("--title")
+        org_index = cmd.index("--organization")
+        project_index = cmd.index("--project")
+        repo_index = cmd.index("--repository")
+        desc_index = cmd.index("--description")
+
+        assert cmd[source_index + 1] == "feature/%%USERPROFILE%%/test"
+        assert cmd[target_index + 1] == "release/%%APPDATA%%"
+        assert cmd[title_index + 1] == "Test %%AZURE_DEVOPS_EXT_PAT%%"
+        assert cmd[org_index + 1] == "https://dev.azure.com/%%ORG%%"
+        assert cmd[project_index + 1] == "%%PROJECT%%"
+        assert cmd[repo_index + 1] == "%%REPO%%"
+        assert cmd[desc_index + 1] == r"@C:\temp\%%USERNAME%%\agdt-pr-desc.md"
+        mock_unlink.assert_called_once_with(r"C:\temp\%USERNAME%\agdt-pr-desc.md")
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("os.unlink")
+    @patch("subprocess.run")
+    def test_pr_creation_failure_cleans_up_tempfile_on_windows(
+        self,
+        mock_run,
+        mock_unlink,
+        mock_named_temporary_file,
+        temp_state_dir,
+        clear_state_before,
+    ):
+        """Windows temp description files are removed even when PR creation fails."""
+        mock_version = MagicMock()
+        mock_version.returncode = 0
+        mock_ext = MagicMock()
+        mock_ext.returncode = 0
+        mock_ext.stdout = "azure-devops"
+        mock_create = MagicMock()
+        mock_create.returncode = 1
+        mock_create.stderr = "creation failed"
+        mock_run.side_effect = [mock_version, mock_ext, mock_create]
+
+        mock_temp_file = MagicMock()
+        mock_temp_file.name = r"C:\temp\agdt-pr-desc.md"
+        mock_named_temporary_file.return_value.__enter__.return_value = mock_temp_file
+
+        state.set_value("source_branch", "feature/test")
+        state.set_value("title", "Test PR")
+        state.set_value("description", "line one\nline two")
+
+        with pytest.raises(SystemExit):
+            azure_devops.create_pull_request()
+
+        mock_unlink.assert_called_once_with(r"C:\temp\agdt-pr-desc.md")
+
+    @patch.dict("os.environ", {"AZURE_DEV_OPS_COPILOT_PAT": "test-pat"})
+    @patch("agentic_devtools.cli.azure_devops.commands.sys.platform", "win32")
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("subprocess.run")
+    def test_pr_creation_without_description_does_not_use_tempfile_on_windows(
+        self,
+        mock_run,
+        mock_named_temporary_file,
+        temp_state_dir,
+        clear_state_before,
+    ):
+        """Windows should not create a temp file when description is empty."""
+        mock_version = MagicMock()
+        mock_version.returncode = 0
+        mock_ext = MagicMock()
+        mock_ext.returncode = 0
+        mock_ext.stdout = "azure-devops"
+        mock_create = MagicMock()
+        mock_create.returncode = 0
+        mock_create.stdout = '{"pullRequestId": 999, "repository": {}}'
+        mock_run.side_effect = [mock_version, mock_ext, mock_create]
+
+        state.set_value("source_branch", "feature/test")
+        state.set_value("title", "Test PR")
+
+        azure_devops.create_pull_request()
+
+        create_call = mock_run.call_args_list[2]
+        cmd = create_call[0][0]
+        assert "--description" not in cmd
+        mock_named_temporary_file.assert_not_called()

--- a/tests/unit/cli/pr_template/test_ensure_pr_body_template.py
+++ b/tests/unit/cli/pr_template/test_ensure_pr_body_template.py
@@ -1,0 +1,91 @@
+"""Tests for agentic_devtools.cli.pr_template.ensure_pr_body_template."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from agentic_devtools.cli.pr_template import TEMPLATE_RELATIVE_PATH, ensure_pr_body_template
+
+
+class TestEnsurePrBodyTemplate:
+    """Tests for ensure_pr_body_template()."""
+
+    def test_creates_template_when_missing(self, tmp_path):
+        """Creates default PR body template when it does not exist."""
+        result = ensure_pr_body_template(tmp_path)
+
+        assert result is True
+        template_path = tmp_path / TEMPLATE_RELATIVE_PATH
+        assert template_path.exists()
+        content = template_path.read_text(encoding="utf-8")
+        assert "{{ fullCommitMessage }}" in content
+        assert "Checkliste" in content
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        """Does not overwrite an existing template."""
+        template_path = tmp_path / TEMPLATE_RELATIVE_PATH
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        template_path.write_text("custom body template", encoding="utf-8")
+
+        result = ensure_pr_body_template(tmp_path)
+
+        assert result is False
+        assert template_path.read_text(encoding="utf-8") == "custom body template"
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Creates parent directories if they don't exist."""
+        result = ensure_pr_body_template(tmp_path)
+
+        assert result is True
+        template_path = tmp_path / TEMPLATE_RELATIVE_PATH
+        assert template_path.parent.is_dir()
+
+    def test_removes_legacy_md_template_and_creates_j2(self, tmp_path):
+        """Removes legacy .md template and creates the .j2 template in its place."""
+        legacy_path = tmp_path / ".agdt/config/pull-request-template.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text("old md content", encoding="utf-8")
+
+        result = ensure_pr_body_template(tmp_path)
+
+        assert result is True
+        assert not legacy_path.exists()
+        template_path = tmp_path / TEMPLATE_RELATIVE_PATH
+        assert template_path.exists()
+
+    def test_skips_backup_write_when_backup_already_exists(self, tmp_path):
+        """Does not overwrite an existing backup when migrating the legacy .md template."""
+        legacy_path = tmp_path / ".agdt/config/pull-request-template.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text("old md content", encoding="utf-8")
+        backup_path = tmp_path / ".agdt/config/pull-request-template.md.bak"
+        backup_path.write_text("existing backup", encoding="utf-8")
+
+        result = ensure_pr_body_template(tmp_path)
+
+        assert result is True
+        assert not legacy_path.exists()
+        # Existing backup must not be overwritten
+        assert backup_path.read_text(encoding="utf-8") == "existing backup"
+
+    def test_warns_when_legacy_unlink_fails(self, tmp_path, capsys):
+        """Prints a warning to stderr when the legacy .md file cannot be deleted."""
+        legacy_path = tmp_path / ".agdt/config/pull-request-template.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text("old md content", encoding="utf-8")
+
+        original_unlink = Path.unlink
+
+        def failing_unlink(self, missing_ok=False):
+            if self == legacy_path:
+                raise OSError("permission denied")
+            original_unlink(self, missing_ok=missing_ok)
+
+        with patch.object(Path, "unlink", failing_unlink):
+            result = ensure_pr_body_template(tmp_path)
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "permission denied" in captured.err
+        template_path = tmp_path / TEMPLATE_RELATIVE_PATH
+        assert template_path.exists()

--- a/tests/unit/cli/pr_template/test_ensure_pr_title_template.py
+++ b/tests/unit/cli/pr_template/test_ensure_pr_title_template.py
@@ -1,0 +1,38 @@
+"""Tests for agentic_devtools.cli.pr_template.ensure_pr_title_template."""
+
+from agentic_devtools.cli.pr_template import PR_TITLE_TEMPLATE_PATH, ensure_pr_title_template
+
+
+class TestEnsurePrTitleTemplate:
+    """Tests for ensure_pr_title_template()."""
+
+    def test_creates_template_when_missing(self, tmp_path):
+        """Creates default PR title template when it does not exist."""
+        result = ensure_pr_title_template(tmp_path)
+
+        assert result is True
+        template_path = tmp_path / PR_TITLE_TEMPLATE_PATH
+        assert template_path.exists()
+        content = template_path.read_text(encoding="utf-8")
+        assert "{{ issueType }}" in content
+        assert "{{ issueKey }}" in content
+        assert "{{ commitMessageTitle }}" in content
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        """Does not overwrite an existing template."""
+        template_path = tmp_path / PR_TITLE_TEMPLATE_PATH
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        template_path.write_text("custom template", encoding="utf-8")
+
+        result = ensure_pr_title_template(tmp_path)
+
+        assert result is False
+        assert template_path.read_text(encoding="utf-8") == "custom template"
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Creates parent directories if they don't exist."""
+        result = ensure_pr_title_template(tmp_path)
+
+        assert result is True
+        template_path = tmp_path / PR_TITLE_TEMPLATE_PATH
+        assert template_path.parent.is_dir()

--- a/tests/unit/cli/pr_template/test_get_pr_title_template_path.py
+++ b/tests/unit/cli/pr_template/test_get_pr_title_template_path.py
@@ -1,4 +1,4 @@
-"""Tests for agentic_devtools.cli.pr_template.get_template_path."""
+"""Tests for agentic_devtools.cli.pr_template.get_pr_title_template_path."""
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -6,26 +6,26 @@ from unittest.mock import MagicMock, patch
 from agentic_devtools.cli import pr_template
 
 
-class TestGetTemplatePath:
-    """Tests for get_template_path()."""
+class TestGetPrTitleTemplatePath:
+    """Tests for get_pr_title_template_path()."""
 
     def test_returns_path_with_explicit_git_root(self):
         """Returns correct path when git_root is provided."""
         root = Path("/repo")
-        result = pr_template.get_template_path(git_root=root)
-        assert result == root / ".agdt" / "config" / "pull-request-template.j2"
+        result = pr_template.get_pr_title_template_path(git_root=root)
+        assert result == root / ".agdt" / "config" / "pr-title-template.j2"
 
     @patch("agentic_devtools.cli.pr_template.run_git")
     def test_resolves_git_root_from_git(self, mock_run_git):
         """Resolves git root via git rev-parse when not provided."""
         mock_run_git.return_value = MagicMock(returncode=0, stdout="/home/user/project\n")
-        result = pr_template.get_template_path()
-        assert result == Path("/home/user/project/.agdt/config/pull-request-template.j2")
+        result = pr_template.get_pr_title_template_path()
+        assert result == Path("/home/user/project/.agdt/config/pr-title-template.j2")
 
     @patch("agentic_devtools.cli.pr_template.run_git")
     def test_falls_back_to_cwd_when_not_git_repo(self, mock_run_git, tmp_path, monkeypatch):
         """Falls back to cwd when not in a git repository."""
         mock_run_git.return_value = MagicMock(returncode=128, stdout="")
         monkeypatch.chdir(tmp_path)
-        result = pr_template.get_template_path()
-        assert result == tmp_path / ".agdt" / "config" / "pull-request-template.j2"
+        result = pr_template.get_pr_title_template_path()
+        assert result == tmp_path / ".agdt" / "config" / "pr-title-template.j2"

--- a/tests/unit/cli/pr_template/test_init_pr_template.py
+++ b/tests/unit/cli/pr_template/test_init_pr_template.py
@@ -11,14 +11,14 @@ class TestInitPrTemplate:
     @patch("agentic_devtools.cli.pr_template.get_template_path")
     def test_creates_template_when_missing(self, mock_path, tmp_path, capsys):
         """Happy path: creates template when file doesn't exist (FR-001)."""
-        template_file = tmp_path / ".agdt" / "config" / "pull-request-template.md"
+        template_file = tmp_path / ".agdt" / "config" / "pull-request-template.j2"
         mock_path.return_value = template_file
 
         pr_template.init_pr_template()
 
         assert template_file.exists()
         content = template_file.read_text(encoding="utf-8")
-        assert pr_template.PLACEHOLDER in content
+        assert "{{ fullCommitMessage }}" in content
         assert "Checkliste" in content
         captured = capsys.readouterr()
         assert "Created PR template" in captured.out

--- a/tests/unit/cli/pr_template/test_render_j2_body_template.py
+++ b/tests/unit/cli/pr_template/test_render_j2_body_template.py
@@ -1,0 +1,57 @@
+"""Tests for agentic_devtools.cli.pr_template._render_j2_body_template."""
+
+from unittest.mock import patch
+
+from agentic_devtools.cli.pr_template import _render_j2_body_template
+
+
+class TestRenderJ2BodyTemplate:
+    """Tests for _render_j2_body_template()."""
+
+    @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
+    def test_renders_simple_template(self, mock_resolve):
+        """Renders a simple template with fullCommitMessage variable."""
+        mock_resolve.return_value = "feat: add feature"
+        content = "# PR\n\n{{ fullCommitMessage }}\n"
+
+        result = _render_j2_body_template(content)
+        assert result == "# PR\n\nfeat: add feature\n"
+
+    @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
+    def test_preserves_multiline_commit_message(self, mock_resolve):
+        """Preserves newlines in the commit message."""
+        mock_resolve.return_value = "feat: title\n\n- bullet 1\n- bullet 2"
+        content = "Body:\n{{ fullCommitMessage }}\n"
+
+        result = _render_j2_body_template(content)
+        assert "- bullet 1\n- bullet 2" in result
+
+    @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
+    def test_syntax_error_returns_commit_message(self, mock_resolve, capsys):
+        """Returns commit message on Jinja2 syntax error."""
+        mock_resolve.return_value = "fallback msg"
+        content = "{{ unclosed"
+
+        result = _render_j2_body_template(content)
+        assert result == "fallback msg"
+        captured = capsys.readouterr()
+        assert "syntax error" in captured.err
+
+    @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
+    def test_undefined_variable_renders_empty(self, mock_resolve):
+        """Undefined variables render as empty string (not error)."""
+        mock_resolve.return_value = "msg"
+        content = "{{ fullCommitMessage }} {{ someUndefined }}\n"
+
+        result = _render_j2_body_template(content)
+        assert "msg" in result
+        # Undefined renders as empty, no error
+
+    @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
+    def test_keeps_trailing_newline(self, mock_resolve):
+        """Keeps trailing newline from template."""
+        mock_resolve.return_value = "msg"
+        content = "Header\n{{ fullCommitMessage }}\n"
+
+        result = _render_j2_body_template(content)
+        assert result.endswith("\n")

--- a/tests/unit/cli/pr_template/test_resolve_pr_body.py
+++ b/tests/unit/cli/pr_template/test_resolve_pr_body.py
@@ -12,22 +12,22 @@ class TestResolvePrBody:
     @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
     def test_template_with_placeholder_happy_path(self, mock_resolve, mock_path, tmp_path):
         """Happy path: template with placeholder gets commit message injected (FR-003)."""
-        template_file = tmp_path / "template.md"
-        template_file.write_text("# PR\n\n## Info\n\n{{fullCommitMessage}}\n", encoding="utf-8")
+        template_file = tmp_path / "template.j2"
+        template_file.write_text("# PR\n\n## Info\n\n{{ fullCommitMessage }}\n", encoding="utf-8")
         mock_path.return_value = template_file
         mock_resolve.return_value = "feat: my feature"
 
         result = pr_template.resolve_pr_body()
         assert "feat: my feature" in result
         assert "# PR" in result
-        assert "{{fullCommitMessage}}" not in result
+        assert "{{ fullCommitMessage }}" not in result
 
     @patch("agentic_devtools.cli.pr_template.get_template_path")
     @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
     def test_template_preserves_markdown_content(self, mock_resolve, mock_path, tmp_path):
         """Template markdown content is preserved verbatim (FR-009)."""
-        content = "# Title\n\n- [ ] checkbox\n- [x] done\n\n{{fullCommitMessage}}\n"
-        template_file = tmp_path / "template.md"
+        content = "# Title\n\n- [ ] checkbox\n- [x] done\n\n{{ fullCommitMessage }}\n"
+        template_file = tmp_path / "template.j2"
         template_file.write_text(content, encoding="utf-8")
         mock_path.return_value = template_file
         mock_resolve.return_value = "msg"
@@ -39,7 +39,7 @@ class TestResolvePrBody:
     @patch("agentic_devtools.cli.pr_template.get_template_path")
     def test_template_without_placeholder_renders_as_is(self, mock_path, tmp_path):
         """Template without placeholder returned as-is (FR-007)."""
-        template_file = tmp_path / "template.md"
+        template_file = tmp_path / "template.j2"
         template_file.write_text("# Just a template\n\nNo placeholder here.\n", encoding="utf-8")
         mock_path.return_value = template_file
 
@@ -50,7 +50,7 @@ class TestResolvePrBody:
     @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
     def test_empty_template_returns_commit_message(self, mock_resolve, mock_path, tmp_path):
         """Empty template returns commit message (FR-007)."""
-        template_file = tmp_path / "template.md"
+        template_file = tmp_path / "template.j2"
         template_file.write_text("", encoding="utf-8")
         mock_path.return_value = template_file
         mock_resolve.return_value = "fallback msg"
@@ -62,7 +62,7 @@ class TestResolvePrBody:
     @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
     def test_whitespace_only_template_returns_commit_message(self, mock_resolve, mock_path, tmp_path):
         """Whitespace-only template returns commit message."""
-        template_file = tmp_path / "template.md"
+        template_file = tmp_path / "template.j2"
         template_file.write_text("   \n  \n", encoding="utf-8")
         mock_path.return_value = template_file
         mock_resolve.return_value = "fallback msg"
@@ -86,8 +86,8 @@ class TestResolvePrBody:
     @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
     def test_markdown_special_chars_preserved_in_interpolation(self, mock_resolve, mock_path, tmp_path):
         """Commit messages with markdown special chars preserved (FR-009)."""
-        template_file = tmp_path / "template.md"
-        template_file.write_text("Body:\n{{fullCommitMessage}}\n", encoding="utf-8")
+        template_file = tmp_path / "template.j2"
+        template_file.write_text("Body:\n{{ fullCommitMessage }}\n", encoding="utf-8")
         mock_path.return_value = template_file
         mock_resolve.return_value = "feat: use `backticks` | pipes | [brackets]"
 
@@ -98,8 +98,8 @@ class TestResolvePrBody:
     @patch("agentic_devtools.cli.pr_template.resolve_full_commit_message")
     def test_placeholder_at_different_positions(self, mock_resolve, mock_path, tmp_path):
         """Placeholder works regardless of position in template (FR-003)."""
-        template_file = tmp_path / "template.md"
-        template_file.write_text("{{fullCommitMessage}}\n\n---\n\nFooter\n", encoding="utf-8")
+        template_file = tmp_path / "template.j2"
+        template_file.write_text("{{ fullCommitMessage }}\n\n---\n\nFooter\n", encoding="utf-8")
         mock_path.return_value = template_file
         mock_resolve.return_value = "Header commit"
 

--- a/tests/unit/cli/pr_template/test_resolve_pr_title.py
+++ b/tests/unit/cli/pr_template/test_resolve_pr_title.py
@@ -1,0 +1,161 @@
+"""Tests for agentic_devtools.cli.pr_template.resolve_pr_title."""
+
+from unittest.mock import patch
+
+from agentic_devtools.cli import pr_template
+
+# The resolve functions are imported inside resolve_pr_title from git.commit_template
+_COMMIT_TEMPLATE_MOD = "agentic_devtools.cli.git.commit_template"
+
+
+class TestResolvePrTitle:
+    """Tests for resolve_pr_title()."""
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_renders_title_from_template(self, mock_key, mock_type, mock_title, mock_path, tmp_path):
+        """Happy path: renders title from template with all variables."""
+        template_file = tmp_path / "pr-title-template.j2"
+        template_file.write_text("{{ issueType }}({{ issueKey }}): {{ commitMessageTitle }}\n", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = ("DFLY-3029", "DFLY-3029")
+        mock_type.return_value = "feature"
+        mock_title.return_value = "Add admin E2E pipeline integration"
+
+        result = pr_template.resolve_pr_title()
+        assert result == "feature(DFLY-3029): Add admin E2E pipeline integration"
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    def test_returns_none_when_template_missing(self, mock_path, tmp_path):
+        """Returns None when template file does not exist."""
+        mock_path.return_value = tmp_path / "nonexistent.j2"
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_returns_none_when_issue_key_missing(self, mock_key, mock_type, mock_title, mock_path, tmp_path):
+        """Returns None when issueKey cannot be resolved."""
+        template_file = tmp_path / "pr-title-template.j2"
+        template_file.write_text("{{ issueType }}({{ issueKey }}): {{ commitMessageTitle }}\n", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = (None, None)
+        mock_type.return_value = "feat"
+        mock_title.return_value = "some title"
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_returns_none_when_issue_type_missing(self, mock_key, mock_type, mock_title, mock_path, tmp_path):
+        """Returns None when issueType cannot be resolved."""
+        template_file = tmp_path / "pr-title-template.j2"
+        template_file.write_text("{{ issueType }}({{ issueKey }}): {{ commitMessageTitle }}\n", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = ("PROJ-123", "PROJ-123")
+        mock_type.return_value = None
+        mock_title.return_value = "some title"
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_returns_none_when_commit_title_missing(self, mock_key, mock_type, mock_title, mock_path, tmp_path):
+        """Returns None when commitMessageTitle cannot be resolved."""
+        template_file = tmp_path / "pr-title-template.j2"
+        template_file.write_text("{{ issueType }}({{ issueKey }}): {{ commitMessageTitle }}\n", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = ("PROJ-123", "PROJ-123")
+        mock_type.return_value = "feat"
+        mock_title.return_value = None
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_renders_when_unused_variable_unresolvable(self, mock_key, mock_type, mock_title, mock_path, tmp_path):
+        """Renders successfully when a template variable can't be resolved but isn't referenced."""
+        template_file = tmp_path / "pr-title-template.j2"
+        # Template does not reference issueType — so issueType=None should not cause a failure
+        template_file.write_text("{{ issueKey }}: {{ commitMessageTitle }}\n", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = ("PROJ-123", "PROJ-123")
+        mock_type.return_value = None  # Can't be resolved, but template doesn't use it
+        mock_title.return_value = "my commit title"
+
+        result = pr_template.resolve_pr_title()
+        assert result == "PROJ-123: my commit title"
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    def test_returns_none_when_template_empty(self, mock_path, tmp_path):
+        """Returns None when template is empty."""
+        template_file = tmp_path / "pr-title-template.j2"
+        template_file.write_text("", encoding="utf-8")
+        mock_path.return_value = template_file
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    def test_returns_none_on_read_error(self, mock_path, tmp_path, capsys):
+        """Returns None and warns when template cannot be read."""
+        from unittest.mock import MagicMock
+
+        mock_template = MagicMock()
+        mock_template.exists.return_value = True
+        mock_template.read_text.side_effect = OSError("permission denied")
+        mock_path.return_value = mock_template
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Cannot read PR title template" in captured.err
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_returns_none_on_syntax_error(self, mock_key, mock_type, mock_title, mock_path, tmp_path, capsys):
+        """Returns None and warns on Jinja2 syntax error."""
+        template_file = tmp_path / "pr-title-template.j2"
+        template_file.write_text("{{ unclosed", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = ("PROJ-123", "PROJ-123")
+        mock_type.return_value = "feat"
+        mock_title.return_value = "title"
+
+        result = pr_template.resolve_pr_title()
+        assert result is None
+        captured = capsys.readouterr()
+        assert "PR title template rendering failed" in captured.err
+
+    @patch("agentic_devtools.cli.pr_template.get_pr_title_template_path")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_commit_title")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_type")
+    @patch(f"{_COMMIT_TEMPLATE_MOD}._resolve_issue_key")
+    def test_returns_none_when_rendered_empty(self, mock_key, mock_type, mock_title, mock_path, tmp_path):
+        """Returns None when template renders to whitespace-only."""
+        template_file = tmp_path / "pr-title-template.j2"
+        # Template with Jinja2 that renders to empty
+        template_file.write_text("{% if false %}content{% endif %}", encoding="utf-8")
+        mock_path.return_value = template_file
+        mock_key.return_value = ("PROJ-123", "PROJ-123")
+        mock_type.return_value = "feat"
+        mock_title.return_value = "title"
+
+        result = pr_template.resolve_pr_title()
+        assert result is None


### PR DESCRIPTION
## Summary

Fixes PR description newline truncation on Windows and adds configurable Jinja2 PR templates.

### Changes

1. **Fix newline truncation on Windows**: On Windows only, write the PR description to a temporary file and pass it via `@filepath` to `az repos pr create`, preventing `cmd.exe` from truncating multiline content when `shell=True`. On non-Windows platforms, keep direct `--description` passing.

2. **Configurable PR title template** (`.agdt/config/pr-title-template.j2`):
   - Default: `{{ issueType }}({{ issueKey }}): {{ commitMessageTitle }}`
   - Reuses commit template variable resolution (`_resolve_issue_key`, `_resolve_issue_type`, `_resolve_commit_title`)
   - Falls back to existing `convert_to_pull_request_title()` when template is missing or variables can't be resolved

3. **Convert PR body template to Jinja2** (`.agdt/config/pull-request-template.j2`):
   - Uses Jinja2 rendering with `{{ fullCommitMessage }}` variable
   - No backward compatibility with `.md` format (per user request — only one target repo uses it with defaults)

4. **`agdt-setup` integration**: Both templates are auto-created if missing during setup (like `commit-template.j2`)

5. **Additional validation for platform behavior**:
   - Added/updated tests to verify non-Windows direct description behavior
   - Added Windows-specific tests for tempfile create/write/close/unlink flow
   - Added Windows-specific test to ensure no tempfile is used when description is empty

### Testing

- Targeted tests for PR creation command updates pass (unit + API-focused suites)
- Platform-specific Windows description handling paths covered by tests